### PR TITLE
Fixes #145 in docker by working of the expected /output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,5 @@ WORKDIR /src/
 RUN python3 ./setup.py install
 
 # Boot commands
+WORKDIR /output
 CMD gutenberg2zim --help ; /bin/bash


### PR DESCRIPTION
Harmonizing the default *output folder* of our container to match other scraper.
As we don't allow specifying a proper output folder, default behavior will work on the pre-configured `/output` of the zimfarm.