### PR TITLE
Fix zip creation and download

### DIFF
--- a/gutenbergtozim/download.py
+++ b/gutenbergtozim/download.py
@@ -203,9 +203,7 @@ def download_book(
 
         if not bfs.count():
             logger.debug(
-                "[{}] not avail. for #{}# {}".format(
-                    book_format, book.id, book.title
-                )
+                "[{}] not avail. for #{}# {}".format(book_format, book.id, book.title)
             )
             continue
 
@@ -218,9 +216,7 @@ def download_book(
             bf = bfs.get()
 
         logger.debug(
-            "[{}] Requesting URLs for #{}# {}".format(
-                book_format, book.id, book.title
-            )
+            "[{}] Requesting URLs for #{}# {}".format(book_format, book.id, book.title)
         )
 
         # retrieve list of URLs for format unless we have it in DB
@@ -308,6 +304,8 @@ def download_book(
             # store working URL in DB
             bf.downloaded_from = url
             bf.save()
+            # break as we got a working URL
+            break
 
         if not bf.downloaded_from and not downloaded_from_cache:
             logger.error("NO FILE FOR #{}/{}".format(book.id, book_format))
@@ -315,7 +313,6 @@ def download_book(
             logger.info("Deleting instance from DB")
             bf.delete_instance()
             pp(allurls)
-            continue
 
 
 def download_covers(book, book_dir, s3_storage, optimizer_version):

--- a/gutenbergtozim/export.py
+++ b/gutenbergtozim/export.py
@@ -572,6 +572,7 @@ def export_book(
             s3_storage=s3_storage,
             optimizer_version=optimizer_version,
         )
+
     write_book_presentation_article(
         static_folder=static_folder,
         book=book,

--- a/gutenbergtozim/s3.py
+++ b/gutenbergtozim/s3.py
@@ -75,7 +75,10 @@ def upload_to_cache(book_id, asset, etag, book_format, s3_storage, optimizer_ver
     if isinstance(asset, list):
         with zipfile.ZipFile(zippath, "w") as zipfl:
             for fl in asset:
-                zipfl.write(fl, arcname=fl.name)
+                if fl.exists():
+                    zipfl.write(fl, arcname=fl.name)
+                else:
+                    logger.error(f"Skipping {fl.name} in S3 zip as it may be corrupt")
         fpath = zippath
     try:
         s3_storage.upload_file(


### PR DESCRIPTION
This does the following -
- Skip corrupted images during zipping for S3 html
- Do not download multiple candidates for a BookFormat (I found out that book 9454 had two candidates for epub and both were downloaded one after the other and the first one was overwritten. Fixed this with a break)

Fixes #122 
