### PR TITLE
Check file existence before exporting in unoptimized_dir

### DIFF
--- a/gutenbergtozim/export.py
+++ b/gutenbergtozim/export.py
@@ -636,6 +636,8 @@ def handle_unoptimized_files(
             update_download_cache(
                 src_dir.joinpath(fname_for(book, "html")), article_fpath
             )
+            if not src_dir.exists():
+                return
         else:
             logger.info("\t\tSkipping HTML article {}".format(article_fpath))
 
@@ -848,17 +850,21 @@ def handle_unoptimized_files(
     for format in formats:
         if format not in book.formats() or format == "html":
             continue
-        try:
-            handle_companion_file(
-                src_dir.joinpath(fname_for(book, format)),
-                archive_name_for(book, format),
-                force=force,
-                book=book,
-                s3_storage=s3_storage,
-            )
-        except Exception as e:
-            logger.exception(e)
-            logger.error("\t\tException while handling companion file: {}".format(e))
+        book_file = src_dir.joinpath(fname_for(book, format))
+        if book_file.exists():
+            try:
+                handle_companion_file(
+                    book_file,
+                    archive_name_for(book, format),
+                    force=force,
+                    book=book,
+                    s3_storage=s3_storage,
+                )
+            except Exception as e:
+                logger.exception(e)
+                logger.error(
+                    "\t\tException while handling companion file: {}".format(e)
+                )
 
 
 def write_book_presentation_article(


### PR DESCRIPTION
This changes the gutenberg behavior to and fixes #124 -
- Do not proceed to process unoptimized_dir if it only contains HTML book
- Check for existence of the other format files to prevent failure if static already has HTML book format

Explanation for doing this - https://github.com/openzim/gutenberg/issues/124#issuecomment-649591245

This has the following changes in handle_unoptimized_files() -
- Return after processing HTML if unoptimized_dir (src_dir in the function) doesn't exists (i.e. removed by update_download_cache())
- Check for the existence of source files to optimize in unoptimized_dir before proceeding with the optimization