### PR TITLE
Raise error on zimwriterfs failure and update download cache always

### DIFF
--- a/gutenbergtozim/export.py
+++ b/gutenbergtozim/export.py
@@ -766,15 +766,16 @@ def handle_unoptimized_files(
         if ext in (".png", ".jpg", ".jpeg", ".gif"):
             logger.info("\t\tCopying and optimizing image companion {}".format(fname))
             optimize_image(src, dst)
-            if dst.name == (f"{book.id}_cover_image.jpg") and s3_storage:
-                upload_to_cache(
-                    asset=dst,
-                    book_format="cover",
-                    book_id=book.id,
-                    etag=book.cover_etag,
-                    s3_storage=s3_storage,
-                    optimizer_version=optimizer_version,
-                )
+            if dst.name == (f"{book.id}_cover_image.jpg"):
+                if s3_storage:
+                    upload_to_cache(
+                        asset=dst,
+                        book_format="cover",
+                        book_id=book.id,
+                        etag=book.cover_etag,
+                        s3_storage=s3_storage,
+                        optimizer_version=optimizer_version,
+                    )
                 update_download_cache(src, dst)
             elif html_file_list:
                 html_file_list.append(dst)
@@ -802,7 +803,7 @@ def handle_unoptimized_files(
                         s3_storage=s3_storage,
                         optimizer_version=optimizer_version,
                     )
-                    update_download_cache(src, dst)
+                update_download_cache(src, dst)
         else:
             # excludes files created by Windows Explorer
             if src.name.endswith("_Thumbs.db"):

--- a/gutenbergtozim/zim.py
+++ b/gutenbergtozim/zim.py
@@ -3,11 +3,12 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 import six
+import subprocess
 
 from path import Path as path
 
 from gutenbergtozim import logger, VERSION
-from gutenbergtozim.utils import exec_cmd, get_project_id, FORMAT_MATRIX
+from gutenbergtozim.utils import get_project_id, FORMAT_MATRIX
 from gutenbergtozim.iso639 import ISO_MATRIX
 from gutenbergtozim.export import export_skeleton
 
@@ -101,7 +102,12 @@ def build_zimfile(
 
     if not create_index:
         cmd.insert(1, "--withoutFTIndex")
-    if exec_cmd(cmd) == 0:
+    zimwriterfs = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
+    )
+    if zimwriterfs.returncode == 0:
         logger.info("Successfuly created ZIM file at {}".format(zim_path))
     else:
         logger.error("Unable to create ZIM file :(")
+        logger.debug(zimwriterfs.stdout)
+        raise SystemExit

--- a/gutenbergtozim/zim.py
+++ b/gutenbergtozim/zim.py
@@ -102,12 +102,9 @@ def build_zimfile(
 
     if not create_index:
         cmd.insert(1, "--withoutFTIndex")
-    zimwriterfs = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
-    )
+    zimwriterfs = subprocess.run(cmd)
     if zimwriterfs.returncode == 0:
         logger.info("Successfuly created ZIM file at {}".format(zim_path))
     else:
         logger.error("Unable to create ZIM file :(")
-        logger.debug(zimwriterfs.stdout)
-        raise SystemExit
+        raise SystemExit(zimwriterfs.returncode)


### PR DESCRIPTION
Runs zimwriterfs directly through subprocess, captures its output, and raises SystemExit if returncode isn't 0. Also logs zimwriterfs output in that case.

Also this allows updating download cache with optimized versions of files if S3 URL was not passed. This makes it helpful for future runs on same dl-cache