### PR TITLE
Small fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ dev
 - added title search option (doesn't scale!)
 - fixed setup_urls on macos
 - add s3 based optimization cache
+- do not allow checking other URLs if downloaded from s3
+- remove book from DB if not downloaded in any format
 
 1.1.5
 - simplified home page results on smaller screen sizes

--- a/gutenbergtozim/download.py
+++ b/gutenbergtozim/download.py
@@ -258,7 +258,7 @@ def download_book(
                         optimizer_version=optimizer_version,
                     ):
                         downloaded_from_cache = True
-                        continue
+                        break
                 if not download_file(url, zpath):
                     logger.error("ZIP file donwload failed: {}".format(zpath))
                     continue
@@ -288,7 +288,7 @@ def download_book(
                             optimizer_version=optimizer_version,
                         ):
                             downloaded_from_cache = True
-                            continue
+                            break
                 if not download_file(url, unoptimized_fpath):
                     logger.error("file donwload failed: {}".format(unoptimized_fpath))
                     continue

--- a/gutenbergtozim/download.py
+++ b/gutenbergtozim/download.py
@@ -201,6 +201,7 @@ def download_book(
                     )
                 )
                 logger.error("html not found")
+                unsuccessful_formats.append(book_format)
                 continue
         else:
             bfs = bfs.filter(
@@ -211,6 +212,7 @@ def download_book(
             logger.debug(
                 "[{}] not avail. for #{}# {}".format(book_format, book.id, book.title)
             )
+            unsuccessful_formats.append(book_format)
             continue
 
         if bfs.count() > 1:
@@ -323,7 +325,10 @@ def download_book(
             pp(allurls)
 
     # delete book from DB if not downloaded in any format
-    if all(format in unsuccessful_formats for format in ["html", "pdf", "epub"]):
+    if len(unsuccessful_formats) == len(formats):
+        logger.debug(
+            f"Book #{book.id} could not be downloaded in any format. Deleting from DB ..."
+        )
         book.delete_instance()
         if book_dir.exists():
             shutil.rmtree(book_dir, ignore_errors=True)

--- a/gutenbergtozim/utils.py
+++ b/gutenbergtozim/utils.py
@@ -110,6 +110,7 @@ def download_file(url, fpath):
             os.unlink(fpath)
         return False
 
+
 def main_formats_for(book):
     fmts = [
         fmt.format.mime

--- a/gutenbergtozim/utils.py
+++ b/gutenbergtozim/utils.py
@@ -99,15 +99,16 @@ def exec_cmd(cmd):
         return subprocess.call(args)
 
 
-def download_file(url, fname=None):
-    fname.parent.mkdir(parents=True, exist_ok=True)
+def download_file(url, fpath):
+    fpath.parent.mkdir(parents=True, exist_ok=True)
     try:
-        save_large_file(url, fname)
+        save_large_file(url, fpath)
         return True
     except Exception as exc:
         logger.error(f"Error while downloading from {url}: {exc}")
+        if fpath.exists():
+            os.unlink(fpath)
         return False
-
 
 def main_formats_for(book):
     fmts = [

--- a/gutenbergtozim/zim.py
+++ b/gutenbergtozim/zim.py
@@ -96,6 +96,7 @@ def build_zimfile(
         "Kiwix",
         "--scraper",
         "gutengergtozim-{v}".format(v=VERSION),
+        "--verbose",
         static_folder,
         six.text_type(zim_path),
     ]


### PR DESCRIPTION
This does the following -

- While downloading something with wget, it seems that it creates a dummy file even if it fails to download anything. This file is now cleaned up properly in download_file(). This happened for some covers.

- Added verbose logging to zimwriterfs

- Previously, even if something was downloaded successfully from optimization cache, the scraper went on to check other URLs and download. This is fixed with proper break statements. 

- Books that could not be downloaded in any format are now removed from DB to prevent errors being thrown at the time of exporting.