### PR TITLE
Display buttons to the various book formats only for requested formats

### DIFF
--- a/gutenbergtozim/database.py
+++ b/gutenbergtozim/database.py
@@ -165,8 +165,8 @@ class Book(BaseModel):
             "cover_page": self.cover_page,
         }
 
-    def to_array(self):
-        fmts = self.formats()
+    def to_array(self, all_requested_formats):
+        fmts = self.requested_formats(all_requested_formats)
         return [
             self.title,
             # self.subtitle,
@@ -187,6 +187,11 @@ class Book(BaseModel):
         from gutenbergtozim.utils import main_formats_for
 
         return main_formats_for(self)
+
+    def requested_formats(self, all_requested_formats):
+        fmts = self.formats()
+        requested_formats = [fmt for fmt in fmts if fmt in all_requested_formats]
+        return requested_formats
 
 
 class BookFormat(BaseModel):

--- a/gutenbergtozim/templates/book_infobox.html
+++ b/gutenbergtozim/templates/book_infobox.html
@@ -3,7 +3,7 @@
     <span class="zim_info">
     <a title="{{ book.title }}" href="{{ book|book_name_for_fs|urlencode }}_cover.{{ book.id }}.html"><i class="fa fa-info-circle fa-2x"></i></a>
     </span>
-    {% for format in book.formats() %}
+    {% for format in book.requested_formats(formats) %}
         {% if not format == 'html' %}
             <span class="zim_{{ format }}">
             <a title="{{ book.title }}: {{ format|upper }}" href="{{ book|book_name_for_fs|urlencode }}.{{ book.id }}.{{ format }}">


### PR DESCRIPTION
Fix #159 

Sample command used for tests (for some tests below, popularity of book 18813 has been tweaked in the extracted RDF in `rdf-files` to be bigger than the popularity of book 18812, so that sorting by popularity/title produces a different result):
```
python gutenberg2zim -z gut_fr_test.zim -b 18812,18813 -f epub,html
```

What has been checked while browsing the resulting ZIM:
- the home page displays two books with only two buttons for epub and html
- the cover page of a given book displays two books with only two buttons for epub and html
- the bookshelf of a given author displays one book with only two buttons for epub and html
- the HTML version of a given book displays only one button for epub
- sorting by popularity / title works as expected