### PR TITLE
Enhance RDF parsing duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ You can find the full arguments list below:
 -l --languages=<list>           Comma-separated list of lang codes to filter export to (preferably ISO 639-1, else ISO 639-3)
 -f --formats=<list>             Comma-separated list of formats to filter export to (epub, html, pdf, all)
 
--r --rdf-folder=<folder>        Don't download rdf-files.tar.bz2 and use extracted folder instead
 -e --static-folder=<folder>     Use-as/Write-to this folder static HTML
 -z --zim-file=<file>            Write ZIM into this file path
 -t --zim-title=<title>          Set ZIM title
@@ -91,16 +90,14 @@ You can find the full arguments list below:
 -d --dl-folder=<folder>         Folder to use/write-to downloaded ebooks
 -u --rdf-url=<url>              Alternative rdf-files.tar.bz2 URL
 -b --books=<ids>                Execute the processes for specific books, separated by commas, or dashes for intervals
--c --concurrency=<nb>           Number of concurrent process for download and parsing tasks
+-c --concurrency=<nb>           Number of concurrent process for processing tasks
 --dlc=<nb>                      Number of concurrent *download* process for download (overwrites --concurrency). if server blocks high rate requests
 -m --one-language-one-zim=<folder> When more than 1 language, do one zim for each   language (and one with all)
 --no-index                      Do NOT create full-text index within ZIM file
 --check                         Check dependencies
---prepare                       Download & extract rdf-files.tar.bz2
+--prepare                       Download rdf-files.tar.bz2
 --parse                         Parse all RDF files and fill-up the DB
 --download                      Download ebooks based on filters
---export                        Export downloaded content to zim-friendly static HTML
---dev                           Exports *just* Home+JS+CSS files (overwritten by --zim step)
 --zim                           Create a ZIM file
 --title-search                  Add field to search a book by title and directly jump to it
 --bookshelves                   Add bookshelves

--- a/gutenberg2zim
+++ b/gutenberg2zim
@@ -12,14 +12,14 @@ from gutenbergtozim import VERSION, logger
 from gutenbergtozim.checkdeps import check_dependencies
 from gutenbergtozim.database import setup_database
 from gutenbergtozim.download import download_all_books
-from gutenbergtozim.rdf import parse_and_fill, setup_rdf_folder
+from gutenbergtozim.rdf import parse_and_fill, download_rdf_file, get_rdf_fpath
 from gutenbergtozim.s3 import s3_credentials_ok
 from gutenbergtozim.urls import setup_urls
 from gutenbergtozim.zim import build_zimfile
 
 help = (
     """Usage: gutenberg2zim [-y] [-F] [-l LANGS] [-f FORMATS] """
-    """[-r RDF_FOLDER] [-d CACHE_PATH] [-e STATIC_PATH] """
+    """[-d CACHE_PATH] [-e STATIC_PATH] """
     """[-z ZIM_PATH] [-u RDF_URL] [-b BOOKS] """
     """[-t ZIM_TITLE] [-n ZIM_DESC] """
     """[-c CONCURRENCY] [--dlc CONCURRENCY] [--no-index] """
@@ -38,8 +38,6 @@ help = (
 -f --formats=<list>             Comma-separated list of formats to filter """
     """export to (epub, html, pdf, all)
 
--r --rdf-folder=<folder>        Don't download rdf-files.tar.bz2 and use """
-    """extracted folder instead
 -e --static-folder=<folder>     Use-as/Write-to this folder static HTML
 -z --zim-file=<file>            Write ZIM into this file path
 -t --zim-title=<title>          Set ZIM title
@@ -88,7 +86,6 @@ def main(arguments):
     ONE_LANG_ONE_ZIM_FOLDER = arguments.get("--one-language-one-zim") or None
     COMPLETE_DUMP = arguments.get("--complete", False)
 
-    RDF_FOLDER = arguments.get("--rdf-folder") or os.path.join("rdf-files")
     ZIM_NAME = arguments.get("--zim-file")
     WIPE_DB = arguments.get("--wipe-db") or False
     RDF_URL = (
@@ -167,9 +164,11 @@ def main(arguments):
             logger.error("Exiting...")
             sys.exit(1)
 
+    rdf_path = get_rdf_fpath()
+
     if DO_PREPARE:
         logger.info("PREPARING rdf-files cache from {}".format(RDF_URL))
-        setup_rdf_folder(rdf_url=RDF_URL, rdf_path=RDF_FOLDER, force=FORCE)
+        download_rdf_file(rdf_url=RDF_URL, rdf_path=rdf_path)
 
     if WIPE_DB:
         logger.info("RESETING DATABASE IF EXISTS")
@@ -177,10 +176,8 @@ def main(arguments):
     setup_database(wipe=WIPE_DB)
 
     if DO_PARSE:
-        logger.info("PARSING rdf-files in {}".format(RDF_FOLDER))
-        parse_and_fill(
-            rdf_path=RDF_FOLDER, only_books=BOOKS, concurrency=CONCURRENCY, force=FORCE
-        )
+        logger.info("PARSING rdf-files in {}".format(rdf_path))
+        parse_and_fill(rdf_path=rdf_path, only_books=BOOKS, force=FORCE)
         logger.info("Add possible url to db")
         setup_urls(force=FORCE)
 

--- a/gutenberg2zim
+++ b/gutenberg2zim
@@ -46,8 +46,8 @@ help = (
 -u --rdf-url=<url>              Alternative rdf-files.tar.bz2 URL
 -b --books=<ids>                Execute the processes for specific books, """
     """separated by commas, or dashes for intervals
--c --concurrency=<nb>           Number of concurrent process for download """
-    """and parsing tasks
+-c --concurrency=<nb>           Number of concurrent process for processing """
+    """tasks
 --dlc=<nb>                      Number of concurrent *download* process for """
     """download (overwrites --concurrency). """
     """if server blocks high rate requests
@@ -55,7 +55,7 @@ help = (
     """language (and one with all)
 --no-index                      Do NOT create full-text index within ZIM file
 --check                         Check dependencies
---prepare                       Download & extract rdf-files.tar.bz2
+--prepare                       Download rdf-files.tar.bz2
 --parse                         Parse all RDF files and fill-up the DB
 --download                      Download ebooks based on filters
 --zim                           Create a ZIM file

--- a/gutenbergtozim/database.py
+++ b/gutenbergtozim/database.py
@@ -58,18 +58,6 @@ class License(BaseModel):
         return self.name
 
 
-class Format(BaseModel):
-    class Meta:
-        database = db
-
-    mime = CharField(max_length=100)
-    images = BooleanField(default=True)
-    pattern = CharField(max_length=100)
-
-    def __unicode__(self):
-        return self.mime
-
-
 class Author(BaseModel):
     class Meta:
         database = db
@@ -199,12 +187,13 @@ class BookFormat(BaseModel):
         database = db
 
     book = ForeignKeyField(Book, related_name="bookformats")
-    format = ForeignKeyField(Format, related_name="bookformats")
+    mime = CharField(max_length=100)
+    images = BooleanField(default=True)
+    pattern = CharField(max_length=100)
     downloaded_from = CharField(max_length=300, null=True)
 
     def __unicode__(self):
-        return "[{}] {}".format(self.format, self.book.title)
-
+        return "[{}] {}".format(self.mime, self.book.title)
 
 class Url(BaseModel):
     class Meta:
@@ -227,7 +216,7 @@ def load_fixtures(model):
 def setup_database(wipe=False):
     logger.info("Setting up the database")
 
-    for model in (License, Format, Author, Book, BookFormat, Url):
+    for model in (License, Author, Book, BookFormat, Url):
         if wipe:
             model.drop_table(fail_silently=True)
         if not model.table_exists():

--- a/gutenbergtozim/download.py
+++ b/gutenbergtozim/download.py
@@ -13,7 +13,7 @@ from pprint import pprint as pp
 from path import Path as path
 
 from gutenbergtozim import TMP_FOLDER, logger
-from gutenbergtozim.database import Book, BookFormat, Format
+from gutenbergtozim.database import Book, BookFormat
 from gutenbergtozim.export import fname_for, get_list_of_filtered_books
 from gutenbergtozim.s3 import download_from_cache
 from gutenbergtozim.urls import get_urls
@@ -181,7 +181,7 @@ def download_book(
                 "8mort10h.zip",
             ]
             bfso = bfs
-            bfs = bfs.join(Format).filter(Format.pattern << patterns)
+            bfs = bfs.filter(BookFormat.pattern << patterns)
             if not bfs.count():
                 pp(
                     list(
@@ -203,9 +203,7 @@ def download_book(
                 unsuccessful_formats.append(book_format)
                 continue
         else:
-            bfs = bfs.filter(
-                BookFormat.format << Format.filter(mime=FORMAT_MATRIX.get(book_format))
-            )
+            bfs = bfs.filter(mime=FORMAT_MATRIX.get(book_format))
 
         if not bfs.count():
             logger.debug(
@@ -216,7 +214,7 @@ def download_book(
 
         if bfs.count() > 1:
             try:
-                bf = bfs.join(Format).filter(Format.images).get()
+                bf = bfs.filter(images).get()
             except Exception:
                 bf = bfs.get()
         else:

--- a/gutenbergtozim/export.py
+++ b/gutenbergtozim/export.py
@@ -23,7 +23,7 @@ from zimscraperlib.image.transformation import resize_image
 
 import gutenbergtozim
 from gutenbergtozim import TMP_FOLDER, TMP_FOLDER_PATH, logger
-from gutenbergtozim.database import Author, Book, BookFormat, Format
+from gutenbergtozim.database import Author, Book, BookFormat
 from gutenbergtozim.iso639 import language_name
 from gutenbergtozim.l10n import l10n_strings
 from gutenbergtozim.s3 import upload_to_cache
@@ -209,12 +209,11 @@ def export_all_books(
             [
                 1
                 for book in books
-                if BookFormat.select(BookFormat, Book, Format)
+                if BookFormat.select(BookFormat, Book)
                 .join(Book)
                 .switch(BookFormat)
-                .join(Format)
                 .where(Book.id == book.id)
-                .where(Format.mime == FORMAT_MATRIX.get(fmt))
+                .where(BookFormat.mime == FORMAT_MATRIX.get(fmt))
                 .count()
             ]
         )

--- a/gutenbergtozim/rdf.py
+++ b/gutenbergtozim/rdf.py
@@ -5,11 +5,10 @@
 import os
 import pathlib
 import re
-from multiprocessing.dummy import Pool
+import tarfile
 
 import peewee
 from bs4 import BeautifulSoup
-from path import Path as path
 
 from gutenbergtozim import logger
 from gutenbergtozim.database import Author, Book, BookFormat, Format, License
@@ -17,105 +16,64 @@ from gutenbergtozim.utils import (
     BAD_BOOKS_FORMATS,
     FORMAT_MATRIX,
     download_file,
-    exec_cmd,
     normalize,
 )
 
 
-def setup_rdf_folder(rdf_url, rdf_path, force=False):
-    """Download and Extract rdf-files"""
-
-    rdf_tarball = download_rdf_file(rdf_url)
-    extract_rdf_files(rdf_tarball, rdf_path, force=force)
-
-
-def download_rdf_file(rdf_url):
+def get_rdf_fpath():
     fname = "rdf-files.tar.bz2"
-
-    if path(fname).exists():
-        logger.info("\trdf-files.tar.bz2 already exists in {}".format(fname))
-        return fname
-
-    logger.info("\tDownloading {} into {}".format(rdf_url, fname))
-    download_file(rdf_url, pathlib.Path(fname).resolve())
-
-    return fname
+    fpath = pathlib.Path(fname).resolve()
+    return fpath
 
 
-def extract_rdf_files(rdf_tarball, rdf_path, force=False):
-    if path(rdf_path).exists() and not force:
-        logger.info("\tRDF-files folder already exists in {}".format(rdf_path))
+def download_rdf_file(rdf_path, rdf_url):
+    """Download rdf-files archive"""
+    if rdf_path.exists():
+        logger.info("\trdf-files archive already exists in {}".format(rdf_path))
         return
 
-    logger.info("\tExtracting {} into {}".format(rdf_tarball, rdf_path))
-
-    # create destdir if not exists
-    dest = path(rdf_path)
-    dest.mkdir_p()
-
-    exec_cmd(
-        [
-            "tar",
-            "-C",
-            rdf_path,
-            "--strip-components",
-            "2",
-            "--extract",
-            "--no-same-owner",
-            "--no-same-permissions",
-            "-f",
-            rdf_tarball,
-        ]
-    )
-    return
+    logger.info("\tDownloading {} into {}".format(rdf_url, rdf_path))
+    download_file(rdf_url, rdf_path)
 
 
-def parse_and_fill(rdf_path, concurrency, only_books=[], force=False):
+def parse_and_fill(rdf_path, only_books=[], force=False):
     logger.info("\tLooping throught RDF files in {}".format(rdf_path))
 
-    fpaths = []
-    for root, dirs, files in os.walk(rdf_path):
-        if root.endswith("999999"):
-            continue
+    rdf_tarfile = tarfile.open(name=rdf_path, mode="r|bz2")
 
-        # skip books outside of requsted list
-        if len(only_books) and path(root).basename() not in [
-            str(bid) for bid in only_books
+    for rdf_member in rdf_tarfile:
+
+        rdf_member_path = pathlib.Path(rdf_member.name)
+
+        # skip books outside of requested list
+        if len(only_books) and rdf_member_path.name not in [
+            "pg{}.rdf".format(bid) for bid in only_books
         ]:
             continue
 
-        for fname in files:
-            if fname in (".", "..", "pg0.rdf"):
-                continue
+        if rdf_member_path.name == "pg0.rdf":
+            continue
 
-            if not fname.endswith(".rdf"):
-                continue
+        if not str(rdf_member_path.name).endswith(".rdf"):
+            continue
 
-            fpaths.append(os.path.join(root, fname))
-
-    fpaths = sorted(
-        fpaths, key=lambda f: int(re.match(r".*/pg([0-9]+).rdf", f).groups()[0])
-    )
-
-    def ppf(x):
-        return parse_and_process_file(x, force)
-
-    Pool(concurrency).map(ppf, fpaths)
+        parse_and_process_file(rdf_tarfile, rdf_member, force)
 
 
-def parse_and_process_file(rdf_file, force=False):
-    if not path(rdf_file).exists():
-        raise ValueError(rdf_file)
+def parse_and_process_file(rdf_tarfile, rdf_member, force=False):
 
-    gid = re.match(r".*/pg([0-9]+).rdf", rdf_file).groups()[0]
+    gid = re.match(r".*/pg([0-9]+).rdf", rdf_member.name).groups()[0]
 
     if Book.get_or_none(id=int(gid)):
-        logger.info("\tSkipping already parsed file {}".format(rdf_file))
+        logger.info(
+            "\tSkipping already parsed file {} for book id {}".format(
+                rdf_member.name, gid
+            )
+        )
         return
 
-    logger.info("\tParsing file {}".format(rdf_file))
-    with open(rdf_file, "r", encoding="UTF-8") as f:
-        parser = RdfParser(f.read(), gid).parse()
+    logger.info("\tParsing file {} for book id {}".format(rdf_member.name, gid))
+    parser = RdfParser(rdf_tarfile.extractfile(rdf_member).read(), gid).parse()
 
     if parser.license == "None":
         logger.info("\tWARN: Unusable book without any information {}".format(gid))

--- a/gutenbergtozim/rdf.py
+++ b/gutenbergtozim/rdf.py
@@ -46,9 +46,7 @@ def parse_and_fill(rdf_path, only_books=[], force=False):
         rdf_member_path = pathlib.Path(rdf_member.name)
 
         # skip books outside of requested list
-        if len(only_books) and rdf_member_path.name not in [
-            "pg{}.rdf".format(bid) for bid in only_books
-        ]:
+        if only_books and rdf_member_path.stem.replace("pg", "") not in only_books:
             continue
 
         if rdf_member_path.name == "pg0.rdf":

--- a/gutenbergtozim/rdf.py
+++ b/gutenbergtozim/rdf.py
@@ -11,7 +11,7 @@ import peewee
 from bs4 import BeautifulSoup
 
 from gutenbergtozim import logger
-from gutenbergtozim.database import Author, Book, BookFormat, Format, License
+from gutenbergtozim.database import Author, Book, BookFormat, License
 from gutenbergtozim.utils import (
     BAD_BOOKS_FORMATS,
     FORMAT_MATRIX,
@@ -274,18 +274,14 @@ def save_rdf_in_database(parser):
             )
             continue
 
-        format_record, _ = Format.get_or_create(
+        # Insert book format
+        BookFormat.create(
+            book=book_record,
             mime=mime,
             images=file_type.endswith(".images")
             or parser.file_types[file_type] == "application/pdf",
-            pattern=pattern,
+            pattern=pattern,            
         )
-
-        # Insert book format
-        BookFormat.get_or_create(
-            book=book_record, format=format_record  # foreign key  # foreign key
-        )
-
 
 def get_formatted_number(num):
     """

--- a/gutenbergtozim/urls.py
+++ b/gutenbergtozim/urls.py
@@ -80,9 +80,7 @@ def get_urls(book):
     param: book: The book you want the possible urls from
     returns: a list of all possible urls sorted by their probability
     """
-    filtered_book = [
-        bf.format for bf in BookFormat.select().where(BookFormat.book == book)
-    ]
+    filtered_book = BookFormat.select().where(BookFormat.book == book)
 
     # Strip out the encoding of the file
     def f(x):

--- a/gutenbergtozim/utils.py
+++ b/gutenbergtozim/utils.py
@@ -18,7 +18,7 @@ from path import Path as path
 from zimscraperlib.download import save_large_file
 
 from gutenbergtozim import logger
-from gutenbergtozim.database import Book, BookFormat, Format
+from gutenbergtozim.database import Book, BookFormat
 from gutenbergtozim.iso639 import language_name
 
 UTF8 = "utf-8"
@@ -113,11 +113,10 @@ def download_file(url, fpath):
 
 def main_formats_for(book):
     fmts = [
-        fmt.format.mime
-        for fmt in BookFormat.select(BookFormat, Book, Format)
+        fmt.mime
+        for fmt in BookFormat.select(BookFormat, Book)
         .join(Book)
         .switch(BookFormat)
-        .join(Format)
         .where(Book.id == book.id)
     ]
     return [k for k, v in FORMAT_MATRIX.items() if v in fmts]
@@ -128,8 +127,7 @@ def get_list_of_filtered_books(languages, formats, only_books=[]):
         qs = (
             Book.select()
             .join(BookFormat)
-            .join(Format)
-            .where(Format.mime << [FORMAT_MATRIX.get(f) for f in formats])
+            .where(BookFormat.mime << [FORMAT_MATRIX.get(f) for f in formats])
             .group_by(Book.id)
         )
     else:

--- a/gutenbergtozim/zim.py
+++ b/gutenbergtozim/zim.py
@@ -100,12 +100,6 @@ def build_zimfile(
             logger.exception(exc)
         return
     else:
-        if Global.creator.can_finish:
-            logger.info("Finishing ZIM file")
-            Global.finish()
-            logger.info(
-                f"Finished Zim {Global.creator.filename.name} "
-                f"in {Global.creator.filename.parent}"
-            )
+        Global.finish()
 
     logger.info("Scraper has finished normally")


### PR DESCRIPTION
As discussed in #97, this PR is a proposition to process the rdf-files.tar.bz2 only from memory. It also has the advantage to use a pure Python implementation for tar processing instead of tar utility.

Previous behavior was:
- download the rdf-files.tar.bz2 file from server and save it on the local filesystem (if not already present)
- extract the individual RDF files on the local filesystem (if not already done)
- process RDF files in parallel (with a default concurrency of 16)

New behavior is:
- download the rdf-files.tar.bz2 file from server and save it on the local filesystem (if not already present)
- process RDF files in sequence from memory, decompression via streaming of the tar.bz2 content

Some timings:
WIP

Some notes:
- there is a significant improvement of streaming the decompression, since it allows to open the file in an efficient manner and not seek in it ; it is faster than parallel processing of the files
- the filtering by book_id (when specified) is still done based on the RDF file name, i.e. we assume that file pg_1234.rdf contains the book id 1234
- the remaining processing time with new behavior is about 1/3 for extractin/parsing the RDF file and 2/3 to process the content/insert it into local DB


