### PR TITLE
Use actions/checkout@v3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Deploy Docker Image
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build and push
         uses: openzim/docker-publish-action@v9
         with:


### PR DESCRIPTION
To fix CI warnings caused by old actions version relying on deprecated Node.js 12.