### PR TITLE
add flag to show verbose output and log output under one name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ as of 2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add support for `--debug` flag to output debug logs
+
 ### Changed
 
 - Insert as few rsync URLs as possible in DB when a book selection is made (#220)
+
+### Fixed
+
+- Simplify the logger named (used `gutenberg2zim` instead of `gutenberg2zim.constants`) (#206)
 
 ## [2.1.1] - 2024-01-17
 

--- a/src/gutenberg2zim/constants.py
+++ b/src/gutenberg2zim/constants.py
@@ -18,7 +18,7 @@ JS_DEPS: list[str] = [
     "datatables/datatables.min.js",
 ]
 
-logger = getLogger(__name__, level=logging.DEBUG)
+logger = getLogger(NAME, level=logging.INFO)
 
 TMP_FOLDER = "tmp"
 TMP_FOLDER_PATH = pathlib.Path(TMP_FOLDER)

--- a/src/gutenberg2zim/entrypoint.py
+++ b/src/gutenberg2zim/entrypoint.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -22,7 +23,8 @@ help_info = (
     """[--prepare] [--parse] [--download] [--export] [--dev] """
     """[--zim] [--complete] [-m ONE_LANG_ONE_ZIM_FOLDER] """
     """[--title-search] [--bookshelves] [--optimization-cache S3URL] """
-    """[--stats-filename STATS_FILENAME] [--publisher ZIM_PUBLISHER]"""
+    """[--stats-filename STATS_FILENAME] [--publisher ZIM_PUBLISHER] """
+    """[--debug]"""
     """
 
 -h --help                       Display this help message
@@ -64,6 +66,7 @@ help_info = (
     """optimization cache
 --stats-filename=<filename>  Path to store the progress JSON file to
 --publisher=<zim_publisher>     Custom Publisher in ZIM Metadata (openZIM otherwise)
+--debug                         Enable verbose output
 
 This script is used to produce a ZIM file (and any intermediate state)
 of Gutenberg repository using a mirror."""
@@ -104,6 +107,11 @@ def main():
     use_any_optimized_version = arguments.get("--use-any-optimized-version", False)
     stats_filename = arguments.get("--stats-filename") or None
     publisher = arguments.get("--publisher") or "openZIM"
+    debug = arguments.get("--debug") or False
+
+    if debug:
+        for handler in logger.handlers:
+            handler.setLevel(logging.DEBUG)
 
     s3_storage = None
     if optimization_cache:


### PR DESCRIPTION
## Rationale
Normalize all log outputs to be under one name instead of module specific loggers and add `--debug` flag for more verbose output. This is intended to be a fix for #206 .

## Changes
- Initialize logger with default level of `INFO` instead of `DEBUG`
- Add `--debug` flag to dynamically set level to `DEBUG`
- When the `--debug` flag is set, update the handlers to have their levels set to `DEBUG` as a simple `logger.setLevel(logging.DEBUG)` only sets it for the logger and not for the handlers. This is akin to what the `getLogger` function from `zimscraperlib` does. After all, it is the handlers that handle output and not the `logger` object.