### PR TITLE
Replace usage of os.path and path.py with pathlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ as of 2.0.0.
 ### Changed
 
 - Insert as few rsync URLs as possible in DB when a book selection is made (#220)
+- Replace usage of os.path and path.py with pathlib.Path (#195)
 
 ### Fixed
 
@@ -102,7 +103,7 @@ as of 2.0.0.
 ## [1.1.6]
 
 - removed duplicate dependencies
-- Added tag _category:gutenberg which was missing
+- Added tag \_category:gutenberg which was missing
 - docker-only release with updated zimwriterfs (2.1.0-1)
 
 ## [1.1.5]

--- a/src/gutenberg2zim/constants.py
+++ b/src/gutenberg2zim/constants.py
@@ -21,4 +21,4 @@ JS_DEPS: list[str] = [
 logger = getLogger(NAME, level=logging.INFO)
 
 TMP_FOLDER = "tmp"
-TMP_FOLDER_PATH = pathlib.Path(TMP_FOLDER)
+TMP_FOLDER_PATH = pathlib.Path(TMP_FOLDER).resolve()

--- a/src/gutenberg2zim/database.py
+++ b/src/gutenberg2zim/database.py
@@ -211,7 +211,7 @@ def load_fixtures(model):
         logger.debug(f"[fixtures] Created {f}")
 
 
-def setup_database(*, wipe=False):
+def setup_database(*, wipe: bool = False) -> None:
     logger.info("Setting up the database")
 
     for model in (License, Author, Book, BookFormat, Url):

--- a/src/gutenberg2zim/download.py
+++ b/src/gutenberg2zim/download.py
@@ -71,10 +71,10 @@ def handle_zipped_epub(zippath: Path, book: Book, dst_dir: Path) -> bool:
     # move all extracted files to proper locations
     for zipped_file in zipped_files:
         # skip folders
-        if not Path(zipped_file).resolve().is_file():
+        if not Path(zipped_file).is_file():
             continue
 
-        src = (Path(tmpd) / zipped_file).resolve()
+        src = Path(tmpd) / zipped_file
         if src.exists():
             fname = Path(zipped_file).name
 

--- a/src/gutenberg2zim/entrypoint.py
+++ b/src/gutenberg2zim/entrypoint.py
@@ -222,12 +222,10 @@ def main():
     for zim_lang in zims:
         if do_zim:
             logger.info("BUILDING ZIM dynamically")
-            if one_lang_one_zim_folder:
-                output_folder = Path(one_lang_one_zim_folder).resolve()
-            else:
-                output_folder = Path(".").resolve()
             build_zimfile(
-                output_folder=output_folder,
+                output_folder=Path(one_lang_one_zim_folder).resolve()
+                if one_lang_one_zim_folder
+                else Path(".").resolve(),
                 download_cache=dl_cache,
                 concurrency=concurrency,
                 languages=zim_lang,

--- a/src/gutenberg2zim/export.py
+++ b/src/gutenberg2zim/export.py
@@ -94,7 +94,7 @@ jinja_env.filters["urlencode"] = urlencode
 
 
 def tmpl_path() -> Path:
-    return (Path(gutenberg2zim.__file__).parent / "templates").resolve()
+    return Path(gutenberg2zim.__file__).parent / "templates"
 
 
 def get_list_of_all_languages():

--- a/src/gutenberg2zim/rdf.py
+++ b/src/gutenberg2zim/rdf.py
@@ -1,7 +1,7 @@
-import os
-import pathlib
 import re
 import tarfile
+from pathlib import Path
+from tarfile import TarFile, TarInfo
 
 import peewee
 from bs4 import BeautifulSoup
@@ -16,13 +16,13 @@ from gutenberg2zim.utils import (
 )
 
 
-def get_rdf_fpath():
+def get_rdf_fpath() -> Path:
     fname = "rdf-files.tar.bz2"
-    fpath = pathlib.Path(fname).resolve()
+    fpath = Path(fname).resolve()
     return fpath
 
 
-def download_rdf_file(rdf_path, rdf_url):
+def download_rdf_file(rdf_path: Path, rdf_url: str) -> None:
     """Download rdf-files archive"""
     if rdf_path.exists():
         logger.info(f"\trdf-files archive already exists in {rdf_path}")
@@ -32,13 +32,13 @@ def download_rdf_file(rdf_path, rdf_url):
     download_file(rdf_url, rdf_path)
 
 
-def parse_and_fill(rdf_path, only_books):
+def parse_and_fill(rdf_path: Path, only_books: list[int]) -> None:
     logger.info(f"\tLooping throught RDF files in {rdf_path}")
 
     rdf_tarfile = tarfile.open(name=rdf_path, mode="r|bz2")
 
     for rdf_member in rdf_tarfile:
-        rdf_member_path = pathlib.Path(rdf_member.name)
+        rdf_member_path = Path(rdf_member.name)
 
         # skip books outside of requested list
         if (
@@ -51,13 +51,13 @@ def parse_and_fill(rdf_path, only_books):
         if rdf_member_path.name == "pg0.rdf":
             continue
 
-        if not str(rdf_member_path.name).endswith(".rdf"):
+        if not rdf_member_path.name.endswith(".rdf"):
             continue
 
         parse_and_process_file(rdf_tarfile, rdf_member)
 
 
-def parse_and_process_file(rdf_tarfile, rdf_member):
+def parse_and_process_file(rdf_tarfile: TarFile, rdf_member: TarInfo) -> None:
     gid = re.match(r".*/pg([0-9]+).rdf", rdf_member.name).groups()[0]  # type: ignore
 
     if Book.get_or_none(id=int(gid)):
@@ -67,11 +67,19 @@ def parse_and_process_file(rdf_tarfile, rdf_member):
         return
 
     logger.info(f"\tParsing file {rdf_member.name} for book id {gid}")
-    parser = RdfParser(rdf_tarfile.extractfile(rdf_member).read(), gid).parse()
+    rdf_data = rdf_tarfile.extractfile(rdf_member)
+    if rdf_data is None:
+        logger.warning(
+            f"Unable to extract member '{rdf_member.name}' from archive "
+            f"'{rdf_member.name}'"
+        )
+        return
+
+    parser = RdfParser(rdf_data.read(), gid).parse()
 
     if parser.license == "None":
         logger.info(f"\tWARN: Unusable book without any information {gid}")
-    elif parser.title == "":
+    elif not parser.title:
         logger.info(f"\tWARN: Unusable book without title {gid}")
     else:
         save_rdf_in_database(parser)
@@ -96,8 +104,8 @@ class RdfParser:
         # The tile of the book: this may or may not be divided
         # into a new-line-seperated title and subtitle.
         # If it is, then we will just split the title.
-        self.title = soup.find("dcterms:title")
-        self.title = self.title.text if self.title else "- No Title -"
+        title = soup.find("dcterms:title")
+        self.title = title.text if title else "- No Title -"
         self.title = self.title.split("\n")[0]
         self.subtitle = " ".join(self.title.split("\n")[1:])
         self.author_id = None
@@ -174,7 +182,7 @@ class RdfParser:
         return self
 
 
-def save_rdf_in_database(parser):
+def save_rdf_in_database(parser: RdfParser) -> None:
     # Insert author, if it not exists
     if parser.author_id:
         try:
@@ -276,7 +284,7 @@ def save_rdf_in_database(parser):
         )
 
 
-def get_formatted_number(num):
+def get_formatted_number(num: str | None) -> str | None:
     """
     Get a formatted string of a number from a not-predictable-string
     that may or may not actually contain a number.
@@ -297,9 +305,9 @@ if __name__ == "__main__":
     nums = [f"{i:0=5d}" for i in range(21000, 40000)]
     for num in nums:
         print(num)  # noqa: T201
-        curd = os.path.dirname(os.path.realpath(__file__))
-        rdf = os.path.join(curd, "..", "rdf-files", num, "pg" + num + ".rdf")
-        if os.path.isfile(rdf):
+        curd = Path(__file__).resolve().parent
+        rdf = curd.parent / "rdf-files" / num / f"pg{num}.rdf"
+        if rdf.is_file():
             data = ""
             with open(rdf) as f:
                 data = f.read()

--- a/src/gutenberg2zim/rdf.py
+++ b/src/gutenberg2zim/rdf.py
@@ -305,7 +305,7 @@ if __name__ == "__main__":
     nums = [f"{i:0=5d}" for i in range(21000, 40000)]
     for num in nums:
         print(num)  # noqa: T201
-        curd = Path(__file__).resolve().parent
+        curd = Path(__file__).parent
         rdf = curd.parent / "rdf-files" / num / f"pg{num}.rdf"
         if rdf.is_file():
             data = ""

--- a/src/gutenberg2zim/urls.py
+++ b/src/gutenberg2zim/urls.py
@@ -18,6 +18,8 @@ class UrlBuilder:
 
     SERVER_NAME = "aleph_pglaf_org"
     RSYNC = "rsync://aleph.pglaf.org/gutenberg/"
+    # NOTE: All urls below should not end with a trailing slash
+    # as they will be added while building the urls for a book.
     BASE_ONE = "http://aleph.pglaf.org"
     BASE_TWO = "http://aleph.pglaf.org/cache/epub"
     BASE_THREE = "http://aleph.pglaf.org/etext"

--- a/src/gutenberg2zim/urls.py
+++ b/src/gutenberg2zim/urls.py
@@ -290,5 +290,5 @@ def setup_urls(force, books):
 
 
 if __name__ == "__main__":
-    book = Book.get(id=84)
+    book = Book.get(id=9)
     print(get_urls(book))  # noqa: T201

--- a/src/gutenberg2zim/urls.py
+++ b/src/gutenberg2zim/urls.py
@@ -1,4 +1,3 @@
-import os
 import urllib.parse as urlparse
 from collections import defaultdict
 
@@ -19,14 +18,14 @@ class UrlBuilder:
 
     SERVER_NAME = "aleph_pglaf_org"
     RSYNC = "rsync://aleph.pglaf.org/gutenberg/"
-    BASE_ONE = "http://aleph.pglaf.org/"
-    BASE_TWO = "http://aleph.pglaf.org/cache/epub/"
+    BASE_ONE = "http://aleph.pglaf.org"
+    BASE_TWO = "http://aleph.pglaf.org/cache/epub"
     BASE_THREE = "http://aleph.pglaf.org/etext"
 
     def __init__(self):
         self.base = self.BASE_ONE
 
-    def build(self):
+    def build(self) -> str:
         """
         Build either an url depending on whether the base url
         is `BASE_ONE` or `BASE_TWO`.
@@ -40,25 +39,24 @@ class UrlBuilder:
         """
         if self.base == self.BASE_ONE:
             if int(self.b_id) > 10:  # noqa: PLR2004
-                base_url = os.path.join(
-                    os.path.join(*list(str(self.b_id))[:-1]), str(self.b_id)
-                )
+                components = "/".join(self.b_id[:-1])
+                base_url = f"{components}/{self.b_id}"
             else:
-                base_url = os.path.join(os.path.join("0", str(self.b_id)))
-            url = os.path.join(self.base, base_url)
+                base_url = f"0/{self.b_id}"
+            url = f"{self.base}/{base_url}"
         elif self.base == self.BASE_TWO:
-            url = os.path.join(self.base, str(self.b_id))
+            url = f"{self.base}/{self.b_id}"
         elif self.base == self.BASE_THREE:
             url = self.base
         return url  # type: ignore
 
-    def with_base(self, base):
+    def with_base(self, base: str) -> None:
         self.base = base
 
-    def with_id(self, b_id):
-        self.b_id = b_id
+    def with_id(self, b_id: str | int) -> None:
+        self.b_id = str(b_id)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.build_url()  # type: ignore
 
 
@@ -145,9 +143,9 @@ def build_epub(files):
         return []
 
     name = "".join(["pg", b_id])
-    url = os.path.join(u.build(), name + ".epub")
-    url_images = os.path.join(u.build(), name + "-images.epub")
-    url_noimages = os.path.join(u.build(), name + "-noimages.epub")
+    url = f"{u.build()}/{name}.epub"
+    url_images = f"{u.build()}/{name}-images.epub"
+    url_noimages = f"{u.build()}/{name}-noimages.epub"
     urls.extend([url, url_images, url_noimages])
     return urls
 
@@ -171,13 +169,13 @@ def build_pdf(files):
 
     for i in files:
         if "images" not in i["name"]:
-            url = os.path.join(u.build(), i["name"])
+            url = f'{u.build()}/{i["name"]}'
             urls.append(url)
 
-    url_dash1 = os.path.join(u1.build(), b_id + "-" + "pdf" + ".pdf")
-    url_dash = os.path.join(u.build(), b_id + "-" + "pdf" + ".pdf")
-    url_normal = os.path.join(u.build(), b_id + ".pdf")
-    url_pg = os.path.join(u.build(), "pg" + b_id + ".pdf")
+    url_dash1 = f"{u1.build()}/{b_id}-pdf.pdf"
+    url_dash = f"{u.build()}/{b_id}-pdf.pdf"
+    url_normal = f"{u.build()}/{b_id}.pdf"
+    url_pg = f"{u.build()}/pg{b_id}.pdf"
 
     urls.extend([url_dash, url_normal, url_pg, url_dash1])
     return list(set(urls))
@@ -198,17 +196,16 @@ def build_html(files):
 
     if all(["-h.html" not in file_names, "-h.zip" in file_names]):
         for i in files:
-            url = os.path.join(u.build(), i["name"])
+            url = f'{u.build()}/{i["name"]}'
             urls.append(url)
 
-    url_zip = os.path.join(u.build(), b_id + "-h" + ".zip")
-    # url_utf8 = os.path.join(u.build(), b_id + '-8' + '.zip')
-    url_html = os.path.join(u.build(), b_id + "-h" + ".html")
-    url_htm = os.path.join(u.build(), b_id + "-h" + ".htm")
+    url_zip = f"{u.build()}/{b_id}-h.zip"
+    url_html = f"{u.build()}/{b_id}-h.html"
+    url_htm = f"{u.build()}/{b_id}-h.htm"
 
     u.with_base(UrlBuilder.BASE_TWO)
     name = "".join(["pg", b_id])
-    html_utf8 = os.path.join(u.build(), name + ".html.utf8")
+    html_utf8 = f"{u.build()}/{name}.html.utf8"
 
     u.with_base(UrlBuilder.BASE_THREE)
     file_index = index_of_substring(files, ["html", "htm"])
@@ -219,7 +216,7 @@ def build_html(files):
     etext_names = [f"{i:0=2d}" for i in etext_nums]
     etext_urls = []
     for i in etext_names:
-        etext_urls.append(os.path.join(u.build() + i, file_name))
+        etext_urls.append(f"{u.build()}{i}/{file_name}")
 
     urls.extend([url_zip, url_htm, url_html, html_utf8])
     urls.extend(etext_urls)
@@ -227,7 +224,7 @@ def build_html(files):
 
 
 def setup_urls(force, books):
-    file_with_url = TMP_FOLDER_PATH.joinpath(f"file_on_{UrlBuilder.SERVER_NAME}")
+    file_with_url = TMP_FOLDER_PATH / f"file_on_{UrlBuilder.SERVER_NAME}"
 
     if file_with_url.exists() and not force:
         logger.info(
@@ -291,5 +288,5 @@ def setup_urls(force, books):
 
 
 if __name__ == "__main__":
-    book = Book.get(id=9)
+    book = Book.get(id=84)
     print(get_urls(book))  # noqa: T201


### PR DESCRIPTION
Fixes #195 

## Rationale

Use `pathlib.Path` for all path operations instead of a combination of `os.path` and `path.py`.

## Changes
- Replace all usages of `os.path` and `path.py` to `pathlib.Path`
- Add type annotations for some parts of the code
- Use f-strings to build urls instead of `os.path.join`