### PR TITLE
Update README and PyPI descriptions; add non-Debian support details

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To view all the available options for `gutenberg2zim`, run:
 docker run ghcr.io/openzim/gutenberg:latest gutenberg2zim --help
 ```
 
+
 ### Arguments
 
 Customize the content download with the following options. For example, to download books in English or French with IDs 100 to 200 and only in PDF format:
@@ -96,16 +97,30 @@ First, ensure you use the proper Python version, inline with the requirement of 
 
 You then need to install the various tools/libraries needed by the scraper.
 
+
 #### GNU/Linux
 
 ```
-sudo apt-get install python-pip python-dev libxml2-dev libxslt-dev advancecomp jpegoptim pngquant p7zip-full gifsicle curl zip zim-tools
+sudo apt update && sudo apt install -y python3-pip libxml2-dev libxslt-dev advancecomp jpegoptim pngquant p7zip-full gifsicle curl zip zim-tools
+
 ```
 
 #### macOS
 
 ```
-brew install advancecomp jpegoptim pngquant p7zip gifsicle
+brew install advancecomp jpegoptim pngquant p7zip gifsicle curl zip zim-tools
+
+```
+
+### Fedora for non debian users
+```
+sudo dnf install -y python3-pip libxml2-devel libxslt-devel advancecomp jpegoptim pngquant p7zip gifsicle curl zip zim-tools
+
+```
+### Arch linux
+```
+sudo pacman -S python-pip libxml2 libxslt advancecomp jpegoptim pngquant p7zip gifsicle curl zip zim-tools
+
 ```
 
 ### Setup the package
@@ -113,7 +128,7 @@ brew install advancecomp jpegoptim pngquant p7zip gifsicle
 First, clone this repository.
 
 ```bash
-git clone git@github.com:kiwix/gutenberg.git
+git clone git@github.com:openzim/gutenberg.git
 cd gutenberg
 ```
 

--- a/pypi-readme.rst
+++ b/pypi-readme.rst
@@ -11,13 +11,26 @@ user friendly format for storing content for offline usage.
 Dependencies
 ------------
 
-Ubuntu/debian
+Ubuntu/Debian
 -------------
 
 .. code-block:: sh
 
-    python-pip python-dev libxml2-dev libxslt-dev advancecomp jpegoptim pngquant p7zip-full gifsicle
+    sudo apt update && sudo apt install -y python3-pip libxml2-dev libxslt-dev advancecomp jpegoptim pngquant p7zip-full gifsicle curl zip zim-tools
 
+Fedora
+------
+
+.. code-block:: sh
+
+    sudo dnf install -y python3-pip libxml2-devel libxslt-devel advancecomp jpegoptim pngquant p7zip gifsicle curl zip zim-tools
+
+Arch Linux
+----------
+
+.. code-block:: sh
+
+    sudo pacman -Syu python-pip libxml2 libxslt advancecomp jpegoptim pngquant p7zip gifsicle curl zip zim-tools
 
 macOS
 -----


### PR DESCRIPTION
This PR  fixes the issue #227 by  updating the README and PyPI description. The main focus is to enhance clarity, fix any inconsistencies because some packages are not required when u only use scraper and include information relevant to non-Debian-based distributions like Arch and Fedora. These changes help ensure that users on different Linux distributions have the necessary details for installation and usage.

README Updates:
Added information about compatibility with Arch, Fedora, and other non-Debian distributions.
also used 
i have used  "sudo apt update && sudo apt install -y python3-pip libxml2-dev libxslt-dev advancecomp jpegoptim pngquant p7zip-full gifsicle curl zip zim-tools" which makes sure all the packages are up to date and used python3 because the previous ones where outdated and did not support arch and fedora
Also changes the pypi-readme.rst for support of arch and fedora which made the overall readme more readable and concise
