### PR TITLE
Add RTL support and language filtering in UI based on user CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ as of 2.0.0.
 - Add support for `-L` long_description flags
 - Add request timeout for util.py (#197)
 - Add Booklanguage DB to support multi-languages books (#218)
+- Add RTL support to UI (#248)
+- Add language filter to combobox for requested languages (#249)
 
 ### Changed
 
@@ -28,9 +30,11 @@ as of 2.0.0.
 - Update multi-resolution favicons (#165)
 
 
+
 ### Fixed
 
 - Simplify the logger named (used `gutenberg2zim` instead of `gutenberg2zim.constants`) (#206)
+
 
 ## [2.1.1] - 2024-01-17
 

--- a/src/gutenberg2zim/export.py
+++ b/src/gutenberg2zim/export.py
@@ -191,6 +191,7 @@ def export_all_books(
     # export to JSON helpers
     export_to_json_helpers(
         books=books,
+        languages=languages,
         formats=formats,
         project_id=project_id,
         add_bookshelves=add_bookshelves,
@@ -949,7 +950,7 @@ def bookshelf_list_language(lang):
     ]
 
 
-def export_to_json_helpers(books, formats, project_id, add_bookshelves):
+def export_to_json_helpers(books, languages, formats, project_id, add_bookshelves):
     def dumpjs(col, fn, var="json_data"):
         Global.add_item_for(
             path=fn,
@@ -978,7 +979,7 @@ def export_to_json_helpers(books, formats, project_id, add_bookshelves):
         "full_by_title.js",
     )
 
-    avail_langs = get_langs_with_count(books=books)
+    avail_langs = get_langs_with_count(books, languages)
     all_filtered_authors = []
 
     # language-specific collections

--- a/src/gutenberg2zim/templates/cover_article.html
+++ b/src/gutenberg2zim/templates/cover_article.html
@@ -29,10 +29,6 @@
                 </p>
             </div>
 
-
-
-
-
             <div class="cover-detail license">
                 <p class="label" data-l10n-id="license">License</p>
                 <p class="label-value"{{ translate_license}}>{{ book.book_license.name }}</p>

--- a/src/gutenberg2zim/templates/css/style.css
+++ b/src/gutenberg2zim/templates/css/style.css
@@ -63,7 +63,7 @@ a {
 
 /* filters */
 .pure-skin-gutenberg .filter {
-    text-align: left;
+    text-align: start;
     margin: 0 1em;
     vertical-align: baseline;
 }
@@ -94,6 +94,7 @@ a {
     float: right;
     margin: 1em 1em 2em;
 }
+
 
 .content {
     width: 100%;
@@ -154,6 +155,20 @@ tr td.table-icons:hover {
     cursor: auto;
 }
 
+.list-stripe {
+    width: .5em;
+    margin-inline-end: .5em;
+    min-height: 5em;
+    background-color: #D00000;
+}
+
+.book-cover-pre {
+    height: 70px;
+    width: 50px;
+    margin-top: 5px;
+    margin-inline-end: 7px;
+}
+
 .table-title {
     font-family: 'RobotoCondensedBold';
     font-size: 1.4em;
@@ -165,12 +180,15 @@ tr td.table-icons:hover {
     color: #333333;
 }
 
-.list-stripe {
-    float: left;
-    width: .5em;
-    margin-right: .5em;
-    min-height: 5em;
-    background-color: #D00000;
+.book-item {
+    display: flex;
+    align-items: flex-start;
+
+  }
+
+.book-item > .pure-g {
+    flex: 1;
+    min-width: 0;
 }
 
 .home-icon {
@@ -200,10 +218,11 @@ dataTables_wrapper.dataTables_length,
 }
 
 .table-icons {
-    text-align: right;
+    text-align: end;
     vertical-align: middle;
     white-space: nowrap;
 }
+
 
 .dataTables_wrapper .dataTables_paginate .paginate_button {
     border: 0!important;
@@ -289,7 +308,7 @@ dataTables_wrapper.dataTables_length,
 
 /* Sort button */
 .sort {
-    text-align: right;
+    text-align: end;
     color: white;
 }
 
@@ -298,7 +317,6 @@ dataTables_wrapper.dataTables_length,
 }
 
 /* cover-only */
-
 body.cover .content {
     margin-top: 0;
     text-align: center;
@@ -347,7 +365,7 @@ body.cover .content h2 {
     max-width: 700px;
     border-collapse: collapse;
     border-spacing: 0;
-    text-align: left;
+    text-align: start;
     font-size: 1.2em;
     background: white;
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
@@ -407,13 +425,6 @@ body.cover .content h2 {
     text-align: center;
 }
 
-.book-cover-pre {
-    height: 70px;
-    width: 50px;
-    margin-right: 5px;
-    margin-top: 5px;
-}
-
 /* mobile */
 
 @media(max-width:768px) {
@@ -446,7 +457,6 @@ body.cover .content h2 {
         margin-top: 0;
     }
 
-
     .filter .pure-g .pure-u-1 {
         margin-bottom: 0.5em;
     }
@@ -476,7 +486,6 @@ body.cover .content h2 {
     .cover-image img {
         max-width: 80%;
     }
-
 }
 
 /* Mobile ; small */

--- a/src/gutenberg2zim/templates/js/l10n.js
+++ b/src/gutenberg2zim/templates/js/l10n.js
@@ -1186,6 +1186,12 @@ document.webL10n = (function(window, document, undefined) {
       return (rtlList.indexOf(gLanguage) >= 0) ? 'rtl' : 'ltr';
     },
 
+    // set the page direction (ltr|rtl) based on current language
+    setDirection: function() {
+      var isRTL = this.getDirection() === 'rtl';
+      document.body.setAttribute('dir', isRTL ? 'rtl' : 'ltr');
+    },
+
     // translate an element or document fragment
     translate: translateFragment,
 

--- a/src/gutenberg2zim/templates/js/tools.js
+++ b/src/gutenberg2zim/templates/js/tools.js
@@ -227,7 +227,7 @@ function showBooks() {
               render: function(data, type, full) {
                 img = '<img class="pure-u-1-8 book-cover-pre" src= "' + full[3] + '_cover_image.jpg"' +
                   'onerror="this.onerror=null;this.style.height=\'50px\';this.src=\'' + 'favicon.png\'" >';
-                div = '<div class="list-stripe"></div>';
+                stripe = '<div class="list-stripe"></div>';
                 title = '<span style="display: none">' + full[3] + '</span>';
                 title += ' <span class = "table-title">' + full[0] + '</span>';
                 author =
@@ -242,7 +242,7 @@ function showBooks() {
                   '<span class="table-author">' + full[1] + '</span>';
                 infoContainer = '<div class="pure-u-7-8">' + title + '<br>' + author + '</div>';
                 innerGrid = '<div class="pure-g">' + img + infoContainer + '</div>';
-                return div + '<div>' + innerGrid + '</div';
+                return '<div class="book-item">' + stripe + innerGrid + '</div>';
               }
             },
             {
@@ -553,13 +553,17 @@ function onLocalized() {
     // console.debug("no persisted lang or equal to browser, updating select");
     l10nselect.val(detectedLang);
   }
+
+  // Check if it's RTL languages and update on direction
+  var isRTL = l10n.getDirection();
+  l10n.setDirection(isRTL);
+
   l10nselect.on("change", function() {
     // console.debug("on change, setting lang " + $(this).val());
     $.persistValue("l10nselect", $(this).val(), persist_options);
     l10n.setLanguage($(this).val());
   });
 }
-
 
 function init() {
   /* Persistence of form values */

--- a/src/gutenberg2zim/utils.py
+++ b/src/gutenberg2zim/utils.py
@@ -115,12 +115,15 @@ def get_list_of_filtered_books(languages, formats, only_books):
     return qs
 
 
-def get_langs_with_count(books):
+def get_langs_with_count(books, languages=None):
     lang_count = {}
 
     for book in books:
         for lang in book.languages:
             code = lang.language_code
+            # if not appear in user request languages list, skip counting
+            if languages and code not in languages:
+                continue
             if code not in lang_count:
                 lang_count[code] = 0
             lang_count[code] += 1


### PR DESCRIPTION
Fix #248 
Fix #249 


**TEST:**
command: python3 -m gutenberg2zim -l ko,it --books 5739,1000 -y 
5739: english, korean
1000: Italian
![image](https://github.com/user-attachments/assets/0d359484-fd98-4696-9cbe-4740770ed590)

**RTL support:**
![image](https://github.com/user-attachments/assets/376a12c1-de81-4501-9af9-564afcb99733)
![image](https://github.com/user-attachments/assets/38c7d8dc-975e-4110-969a-93eba069d8a8)

(Definitely RTL could be better with better general UI. lmao



**Question:** 
Copyrighted does not have locales implementation. would this become a problem?
![image](https://github.com/user-attachments/assets/26cb671f-fd2a-4f58-ab24-fd284bcf2808)
