### PR TITLE
Retry book download on HTTP error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ as of 2.0.0.
 ### Fixed
 
 - Simplify the logger named (used `gutenberg2zim` instead of `gutenberg2zim.constants`) (#206)
+- Add retry logic on book downloads (#254)
 
 
 ## [2.1.1] - 2024-01-17


### PR DESCRIPTION
With https://github.com/openzim/gutenberg/pull/242, we've moved from wget to requests to download books.

However, this means we do not have anymore automated retries when server is down. This is a good news since it will solve https://github.com/openzim/gutenberg/issues/142, but it also means scraper is now more fragile.

This PR introduces automated retries of all exceptions linked to the HTTP requests, except for all codes between 400 and 499 which are not retried since they are deemed to fail, except 429 which is also retried.

Retry backoff is exponential with significant base and exponential factor to let upstream server breath.