### PR TITLE
Change mirror and add CLI flag to set mirror URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ as of 2.0.0.
 
 ### Breaking
 
-- Remove any optimization logic + use of S3 cache (#300)
+- Remove any optimization logic + use of S3 cache, dropping `--optimization-cache` and `--use-any-optimized-version` flags (#300)
+- Move to another default mirror + add CLI flag to select mirror to use, dropping `--rdf-url` flag and adding `--mirror_url` CLI flag (#301)
 
 ### Changed
 
 - Finalize implementation of scraper progress (#289)
+- Move to another default mirror + add CLI flag to select mirror to use (#301)
 
 ## [2.2.0] - 2025-06-06
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ You can find the full arguments list below:
 -n --zim-desc=<description>     Set ZIM description
 -L --zim-long-desc=<description> Set ZIM long description
 -d --dl-folder=<folder>         Folder to use/write-to downloaded ebooks
--u --rdf-url=<url>              Alternative rdf-files.tar.bz2 URL
 -b --books=<ids>                Execute the processes for specific books, separated by commas, or dashes for intervals
 -c --concurrency=<nb>           Number of concurrent process for processing tasks
 --dlc=<nb>                      Number of concurrent *download* process for download (overwrites --concurrency). if server blocks high rate requests

--- a/src/gutenberg2zim/entrypoint.py
+++ b/src/gutenberg2zim/entrypoint.py
@@ -23,7 +23,7 @@ help_info = (
     """[--zim] [--complete] [-m ONE_LANG_ONE_ZIM_FOLDER] """
     """[--title-search] [--bookshelves] """
     """[--stats-filename STATS_FILENAME] [--publisher ZIM_PUBLISHER] """
-    """[--debug]"""
+    """[--mirror-url MIRROR_URL] [--debug] """
     """
 
 -h --help                       Display this help message
@@ -42,7 +42,6 @@ help_info = (
 -L --zim-long-desc=<description>   Set ZIM long description
 
 -d --dl-folder=<folder>         Folder to use/write-to downloaded ebooks
--u --rdf-url=<url>              Alternative rdf-files.tar.bz2 URL
 -b --books=<ids>                Execute the processes for specific books, """
     """separated by commas, or dashes for intervals
 -c --concurrency=<nb>           Number of concurrent process for processing """
@@ -62,6 +61,7 @@ help_info = (
 --bookshelves                   Add bookshelves
 --stats-filename=<filename>  Path to store the progress JSON file to
 --publisher=<zim_publisher>     Custom Publisher in ZIM Metadata (openZIM otherwise)
+--mirror_url=<mirror_url>       Optional custom url of mirror hosting Gutenberg files
 --debug                         Enable verbose output
 
 This script is used to produce a ZIM file (and any intermediate state)
@@ -82,10 +82,7 @@ def main():
 
     zim_name = arguments.get("--zim-file")
     wipe_db = arguments.get("--wipe-db") or False
-    rdf_url = (
-        arguments.get("--rdf-url")
-        or "http://www.gutenberg.org/cache/epub/feeds/rdf-files.tar.bz2"
-    )
+    mirror_url = arguments.get("--mirror-url") or "https://gutenberg.mirror.driftle.ss"
 
     if dl_folder := arguments.get("--dl-folder"):
         dl_cache = Path(dl_folder).resolve()
@@ -167,6 +164,7 @@ def main():
     progress = ScraperProgress(stats_filename)
 
     if do_prepare:
+        rdf_url = f"{mirror_url}/cache/epub/feeds/rdf-files.tar.bz2"
         logger.info(f"PREPARING rdf-files cache from {rdf_url}")
         download_rdf_file(rdf_url=rdf_url, rdf_path=rdf_path)
 
@@ -183,6 +181,7 @@ def main():
     if do_download:
         logger.info("DOWNLOADING ebooks from mirror using filters")
         download_all_books(
+            mirror_url=mirror_url,
             download_cache=dl_cache,
             concurrency=dl_concurrency,
             languages=languages,

--- a/src/gutenberg2zim/pg_archive_urls.py
+++ b/src/gutenberg2zim/pg_archive_urls.py
@@ -2,6 +2,7 @@
 
 # This file has been retrieved from https://github.com/gutenbergtools/libgutenberg/blob/master/pg_archive_urls.py
 # and should be kept in sync manually
+# Last sync: March 29 2025 with https://github.com/gutenbergtools/libgutenberg/commit/be9866b9c2c97b41983265636bd2fa988f159faa
 
 """
 
@@ -63,7 +64,7 @@ def archive_dir(ebook):
     return "/".join(a)
 
 
-def archive_url(pg_url, netloc="aleph.pglaf.org", scheme="http"):
+def archive_url(pg_url, mirror_url):
     """translate pg canonical url to an archive url"""
     if not pg_url:
         return None
@@ -71,17 +72,17 @@ def archive_url(pg_url, netloc="aleph.pglaf.org", scheme="http"):
     matched = MATCH_TYPE.search(path)
     if matched and matched.group(2) in FILENAMES:
         fn = FILENAMES[matched.group(2)].format(id=matched.group(1))
-        return f"{scheme}://{netloc}/cache/epub/{matched.group(1)}/{fn}"
+        return f"{mirror_url}/cache/epub/{matched.group(1)}/{fn}"
     matched = MATCH_DIRS.search(path)
     if matched:
-        return f"{scheme}://{netloc}/{archive_dir(matched.group(1))}/{matched.group(2)}"
-    return f"{scheme}://{netloc}{path}"
+        return f"{mirror_url}/{archive_dir(matched.group(1))}/{matched.group(2)}"
+    return f"{mirror_url}{path}"
 
 
-def url_for_type(pg_type, book_id, netloc="aleph.pglaf.org", scheme="http"):
+def url_for_type(pg_type, book_id, mirror_url):
     if pg_type in FILENAMES:
         fn = FILENAMES[pg_type].format(book_id=book_id)
-        return f"{scheme}://{netloc}/cache/epub/{book_id}/{fn}"
+        return f"{mirror_url}/cache/epub/{book_id}/{fn}"
 
 
 # example1 = "https://www.gutenberg.org/ebooks/12345.html.images"


### PR DESCRIPTION
`aleph.pglaf.org` is pretty slow ATM and we have a volunteer which setup a new mirror at `gutenberg.mirror.driftle.ss`.

This mirror is way faster. It probably suffer from few minutes / hours offset in terms of sync, but we should probably not care.

This change is obviously not definitive, even if it might stay for quite a long time, at least it unblocks current situation where scrapes take long in part due to this server being very slow.

This PR also adds a `--mirror-url` flag to allow to customize mirror used without having to release scraper again, and ensures we have a homogeneous use of same mirror throughout the whole processing.

To be merged after https://github.com/openzim/gutenberg/pull/300