### PR TITLE
Stop ignoring HTML illustrations containing cover in their name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ as of 2.0.0.
 - Move to another default mirror + add CLI flag to select mirror to use (#301)
 - Split build logic in Dockerfile to separate dependencies layer from scraper code layer (#302)
 
+### Fixed
+
+- Stop ignoring HTML illustrations containing cover in their name (#270)
+
 ## [2.2.0] - 2025-06-06
 
 ### Added

--- a/src/gutenberg2zim/download.py
+++ b/src/gutenberg2zim/download.py
@@ -85,10 +85,6 @@ def handle_zipped_html(zippath: Path, book: Book, dst_dir: Path) -> bool:
         if not Path(src).is_file():
             continue
 
-        # skip cover images
-        if "cover" in zipped_file:
-            continue
-
         if src.exists():
             fname = Path(zipped_file).name
 
@@ -135,11 +131,13 @@ def download_book(
         formats.append("html")
 
     book_dir = download_cache / str(book.book_id)
+    cover_dir = download_cache / "covers"
 
     if force:
         shutil.rmtree(book_dir)
 
     book_dir.mkdir(parents=True, exist_ok=True)
+    cover_dir.mkdir(parents=True, exist_ok=True)
 
     unsupported_formats = []
     for book_format in formats:
@@ -237,22 +235,20 @@ def download_book(
         if book_dir.exists():
             shutil.rmtree(book_dir, ignore_errors=True)
         return
-    download_cover(mirror_url, book, book_dir)
 
-
-def download_cover(mirror_url, book, book_dir):
+    # download cover image
     has_cover = Book.select(Book.cover_page).where(Book.book_id == book.book_id)
     if has_cover:
         url = (
             f"{mirror_url}/cache/epub/{book.book_id}/pg{book.book_id}.cover.medium.jpg"
         )
         cover = f"{book.book_id}_cover_image.jpg"
-        if (book_dir / cover).exists():
+        if (cover_dir / cover).exists():
             logger.debug(f"Cover already exists for book #{book.book_id}")
             return
 
         logger.debug(f"Downloading {url}")
-        download_file(url, book_dir / cover)
+        download_file(url, cover_dir / cover)
     else:
         logger.debug(f"No Book Cover found for Book #{book.book_id}")
 

--- a/src/gutenberg2zim/export.py
+++ b/src/gutenberg2zim/export.py
@@ -526,16 +526,18 @@ def export_book(
 ):
     logger.debug(f"Exporting book {book.book_id}")
     book_dir = download_cache / str(book.book_id)
+    cover_dir = download_cache / "covers"
     handle_book_files(
         book=book,
         src_dir=book_dir,
+        cover_dir=cover_dir,
         formats=formats,
         force=force,
     )
 
     write_book_presentation_article(
         book=book,
-        optimized_files_dir=book_dir,
+        cover_dir=cover_dir,
         force=force,
         project_id=project_id,
         title_search=title_search,
@@ -548,6 +550,7 @@ def export_book(
 def handle_book_files(
     book: Book,
     src_dir: Path,
+    cover_dir: Path,
     formats: list[str],
     *,
     force: bool,
@@ -626,10 +629,18 @@ def handle_book_files(
                 logger.exception(e)
                 logger.error(f"\t\tException while handling companion file: {e}")
 
+    # cover image
+    cover_img = cover_dir / f"{book.book_id}_cover_image.jpg"
+    if cover_img.exists():
+        handle_companion_file(
+            fname=cover_img,
+            dstfname=f"covers/{book.book_id}_cover_image.jpg",
+        )
+
 
 def write_book_presentation_article(
     book,
-    optimized_files_dir,
+    cover_dir,
     force,
     project_id,
     title_search,
@@ -643,7 +654,7 @@ def write_book_presentation_article(
         logger.info(f"\t\tExporting article presentation to {cover_fpath}")
         html = cover_html_content_for(
             book=book,
-            cover_dir=optimized_files_dir,
+            cover_dir=cover_dir,
             books=books,
             project_id=project_id,
             title_search=title_search,

--- a/src/gutenberg2zim/templates/cover_article.html
+++ b/src/gutenberg2zim/templates/cover_article.html
@@ -9,7 +9,7 @@
 
         {% if cover_img %}
         <div class="pure-u-1 pure-u-md-1-2 cover-image">
-            <img data-l10n-id="cover-img" class="cover-art" src="{{ cover_img }}" title="Book Cover" alt="Book Cover" />
+            <img data-l10n-id="cover-img" class="cover-art" src="./covers/{{ cover_img }}" title="Book Cover" alt="Book Cover" />
         </div>
         <div class="pure-u-1 pure-u-md-1-2 bibrec sidedimg">
         {% else %}

--- a/src/gutenberg2zim/templates/js/tools.js
+++ b/src/gutenberg2zim/templates/js/tools.js
@@ -225,7 +225,7 @@ function showBooks() {
             {
               targets: 0,
               render: function(data, type, full) {
-                img = '<img class="pure-u-1-8 book-cover-pre" src= "' + full[3] + '_cover_image.jpg"' +
+                img = '<img class="pure-u-1-8 book-cover-pre" src= "./covers/' + full[3] + '_cover_image.jpg"' +
                   'onerror="this.onerror=null;this.style.height=\'50px\';this.src=\'' + 'favicon.png\'" >';
                 stripe = '<div class="list-stripe"></div>';
                 title = '<span style="display: none">' + full[3] + '</span>';
@@ -418,7 +418,7 @@ function showBookshelf(bookshelfURL) {
             {
               targets: 0,
               render: function(data, type, full) {
-                img = '<img class="pure-u-1-8 book-cover-pre" src= "' + full[3] + '_cover_image.jpg"' +
+                img = '<img class="pure-u-1-8 book-cover-pre" src= "./covers/' + full[3] + '_cover_image.jpg"' +
                   'onerror="this.onerror=null;this.style.height=\'50px\';this.src=\'' + 'favicon.png\'" >';
                 div = '<div class="list-stripe"></div>';
                 title = '<span style="display: none">' + full[3] + '</span>';


### PR DESCRIPTION
Fix #270

To be merged after https://github.com/openzim/gutenberg/pull/302

Changes:
- when downloading, do not mix cover image with HTML content, store cover images in a dedicated folder
- when exporting, store cover images in a dedicated `covers/` path