### PR TITLE
Remove « .html » extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ as of 2.0.0.
 - Move to another default mirror + add CLI flag to select mirror to use (#301)
 - Split build logic in Dockerfile to separate dependencies layer from scraper code layer (#302)
 - Prepare structure for TranslateWiki (#312)
+- Remove « .html » extension (#166)
 
 ### Fixed
 

--- a/src/gutenberg2zim/export.py
+++ b/src/gutenberg2zim/export.py
@@ -147,11 +147,10 @@ def export_skeleton(
                 Global.add_item_for(path=str(Path(fname) / path), fpath=fpath)
 
     # export homepage
-    tpl_path = "Home.html"
-    template = jinja_env.get_template(tpl_path)
+    template = jinja_env.get_template("Home.html")
     rendered = template.render(**context)
     Global.add_item_for(
-        path=tpl_path,
+        path="Home",
         content=rendered,
         mimetype="text/html",
         is_front=True,
@@ -442,7 +441,7 @@ def author_html_content_for(author, project_id):
 def save_author_file(author, project_id):
     logger.debug(f"\t\tSaving author file {author.name()} (ID {author})")
     Global.add_item_for(
-        path=f"{author.fname()}.html",
+        path=f"{author.fname()}",
         content=author_html_content_for(author, project_id),
         mimetype="text/html",
         is_front=True,
@@ -791,13 +790,13 @@ def export_to_json_helpers(languages, formats, project_id, add_lcc_shelves):
         dumpjs(lcc_shelf_list(), "lcc_shelves.js", "lcc_shelves_json_data")
 
         # Create the LCC shelf home page
-        logger.debug("\t\tDumping lcc_shelf_home.html")
+        logger.debug("\t\tDumping lcc_shelf_home (HTML)")
         context = get_default_context(project_id=project_id)
         context.update({"lcc_shelf_home": True, "add_lcc_shelves": True})
         template = jinja_env.get_template("lcc_shelf_home.html")
         rendered = template.render(**context)
         Global.add_item_for(
-            path="lcc_shelf_home.html",
+            path="lcc_shelf_home",
             content=rendered,
             mimetype="text/html",
             is_front=False,
@@ -807,7 +806,7 @@ def export_to_json_helpers(languages, formats, project_id, add_lcc_shelves):
         for lcc_shelf in lcc_shelf_list():
             if lcc_shelf is None:
                 continue
-            logger.debug(f"Dumping lcc_shelf_{lcc_shelf}.html")
+            logger.debug(f"Dumping lcc_shelf_{lcc_shelf} (HTML)")
             context["lcc_shelf"] = lcc_shelf
             context.update(
                 {
@@ -821,7 +820,7 @@ def export_to_json_helpers(languages, formats, project_id, add_lcc_shelves):
             template = jinja_env.get_template("lcc_shelf.html")
             rendered = template.render(**context)
             Global.add_item_for(
-                path=f"lcc_shelf_{lcc_shelf}.html",
+                path=f"lcc_shelf_{lcc_shelf}",
                 content=rendered,
                 mimetype="text/html",
                 is_front=False,

--- a/src/gutenberg2zim/shared.py
+++ b/src/gutenberg2zim/shared.py
@@ -40,7 +40,7 @@ class Global:
         Global.creator = (
             Creator(
                 filename=filename,
-                main_path="Home.html",
+                main_path="Home",
                 workaround_nocancel=False,
             )
             .config_metadata(

--- a/src/gutenberg2zim/templates/base.html
+++ b/src/gutenberg2zim/templates/base.html
@@ -50,8 +50,8 @@
     </div>
     <header>
         <div class="main_title">
-            <h1><a href="Home.html" data-l10n-id="top-title">Project Gutenberg Library</a></h1>
-            <h2><a href="Home.html" data-l10n-id="sub-title">The first producer of free ebooks</a></h2>
+            <h1><a href="./Home" data-l10n-id="top-title">Project Gutenberg Library</a></h1>
+            <h2><a href="./Home" data-l10n-id="sub-title">The first producer of free ebooks</a></h2>
         </div>
 
         <div class="pure-form filter">
@@ -81,13 +81,13 @@
 
                         {% if add_lcc_shelves %}
                             {% if show_books %}
-                                <a class="nav-link" href="lcc_shelf_home.html" data-l10n-id="lcc_shelf_link">Browse by Bookshelves</a>
+                                <a class="nav-link" href="./lcc_shelf_home" data-l10n-id="lcc_shelf_link">Browse by Bookshelves</a>
                             {% else %}
-                                <a class="nav-link" href="Home.html" data-l10n-id="home_link"> Go Home</a>
+                                <a class="nav-link" href="./Home" data-l10n-id="home_link"> Go Home</a>
                             {% endif %}
                         {% else %}
                             {% if not show_books %}
-                                <a class="nav-link" href="Home.html" data-l10n-id="home_link"> Go Home</a>
+                                <a class="nav-link" href="./Home" data-l10n-id="home_link"> Go Home</a>
                             {% endif %}
                         {% endif %}
                 </section>

--- a/src/gutenberg2zim/templates/book_infobox.html
+++ b/src/gutenberg2zim/templates/book_infobox.html
@@ -1,7 +1,7 @@
 <div>
     <link rel="stylesheet" href="fonts/font-awesome/css/font-awesome.css">
     <span class="zim_info">
-    <a title="{{ book.title }}" href="{{ book|book_name_for_fs|urlencode }}_cover.{{ book.book_id }}.html"><i class="fa fa-info-circle fa-2x"></i></a>
+    <a title="{{ book.title }}" href="./{{ book|book_name_for_fs|urlencode }}_cover.{{ book.book_id }}"><i class="fa fa-info-circle fa-2x"></i></a>
     </span>
     {% for format in book.requested_formats(formats) %}
         {% if not format == 'html' %}

--- a/src/gutenberg2zim/templates/cover_article.html
+++ b/src/gutenberg2zim/templates/cover_article.html
@@ -43,7 +43,11 @@
             {% if formats %}
             <div class="cover-detail icons-footer">
                 {% for format in formats %}
+                    {% if format == "html" %}
+                <a title="{{ book.title }}: {{ format|upper }}" href="{{ book|book_name_for_fs|urlencode }}.{{ book.book_id }}">
+                    {% else %}
                 <a title="{{ book.title }}: {{ format|upper }}" href="{{ book|book_name_for_fs|urlencode }}.{{ book.book_id }}.{{ format }}">
+                    {% endif %}
                     {% if format == "html" %}
                     <i class="fa fa-html5 fa-6x"></i>
                     {% endif %}

--- a/src/gutenberg2zim/templates/js/tools.js
+++ b/src/gutenberg2zim/templates/js/tools.js
@@ -176,7 +176,7 @@ function showBooks() {
     // redirect to home page
     if (is_cover_page()) {
       console.log("Cover page, redirecting");
-      $(location).attr("href", "Home.html");
+      $(location).attr("href", "Home");
     } else {
       console.log("NOT COVER PAGE");
     }
@@ -263,15 +263,15 @@ function showBooks() {
                   html +=
                     '<a class="home-icon" title="' +
                     full[0] +
-                    ': HTML" href="' +
+                    ': HTML" href="./' +
                     urlBase +
-                    '.html"><i class="fa fa-html5 fa-3x"></i></a>';
+                    '"><i class="fa fa-html5 fa-3x"></i></a>';
                 }
                 if (data[1] == 1) {
                   html +=
                     '<a class="home-icon" title="' +
                     full[0] +
-                    ': EPUB" href="' +
+                    ': EPUB" href="./' +
                     urlBase +
                     '.epub"><i class="fa fa-download fa-3x"></i></a>';
                 }
@@ -279,7 +279,7 @@ function showBooks() {
                   html +=
                     '<a class="home-icon" title="' +
                     full[0] +
-                    ': PDF" href="' +
+                    ': PDF" href="./' +
                     urlBase +
                     '.pdf"><i class="fa fa-file-pdf-o fa-3x"></i></a>';
                 }
@@ -303,8 +303,7 @@ function showBooks() {
             "href",
             encodeURIComponent(titre.replace("/", "-").substring(0, 230)) +
             "_cover." +
-            id +
-            ".html"
+            id
           );
         } else if (event.which == 2) {
           /* Middle click */
@@ -313,7 +312,6 @@ function showBooks() {
             encodeURIComponent(titre.replace("/", "-").substring(0, 230)) +
             "_cover." +
             id +
-            ".html" +
             "' />"
           );
           link.attr("target", "_blank");
@@ -359,7 +357,7 @@ function showLccShelf(lcc_shelf) {
     // redirect to home page
     // if (is_cover_page()) {
     //   console.log("Cover page, redirecting");
-    //   $(location).attr("href", "Home.html");
+    //   $(location).attr("href", "Home");
     // } else {
     //   console.log("NOT COVER PAGE");
     // }
@@ -455,15 +453,15 @@ function showLccShelf(lcc_shelf) {
                   html +=
                     '<a class="home-icon" title="' +
                     full[0] +
-                    ': HTML" href="' +
+                    ': HTML" href="./' +
                     urlBase +
-                    '.html"><i class="fa fa-html5 fa-3x"></i></a>';
+                    '"><i class="fa fa-html5 fa-3x"></i></a>';
                 }
                 if (data[1] == 1) {
                   html +=
                     '<a class="home-icon" title="' +
                     full[0] +
-                    ': EPUB" href="' +
+                    ': EPUB" href="./' +
                     urlBase +
                     '.epub"><i class="fa fa-download fa-3x"></i></a>';
                 }
@@ -471,7 +469,7 @@ function showLccShelf(lcc_shelf) {
                   html +=
                     '<a class="home-icon" title="' +
                     full[0] +
-                    ': PDF" href="' +
+                    ': PDF" href="./' +
                     urlBase +
                     '.pdf"><i class="fa fa-file-pdf-o fa-3x"></i></a>';
                 }
@@ -495,8 +493,7 @@ function showLccShelf(lcc_shelf) {
             "href",
             encodeURIComponent(titre.replace("/", "-").substring(0, 230)) +
             "_cover." +
-            id +
-            ".html"
+            id
           );
         } else if (event.which == 2) {
           /* Middle click */
@@ -505,7 +502,6 @@ function showLccShelf(lcc_shelf) {
             encodeURIComponent(titre.replace("/", "-").substring(0, 230)) +
             "_cover." +
             id +
-            ".html" +
             "' />"
           );
           link.attr("target", "_blank");
@@ -710,7 +706,7 @@ function init() {
     },
     select: function(event, ui) {
       minimizeUI();
-      let url = "./" + encodeURIComponent(ui.item.value.replace(/\//g, "-")) + "_cover." + title_dict[ui.item.value] + ".html";
+      let url = "./" + encodeURIComponent(ui.item.value.replace(/\//g, "-")) + "_cover." + title_dict[ui.item.value];
       $(location).attr("href", url);
     }
   });
@@ -722,7 +718,7 @@ function init() {
         return;
       }
 
-      let url = "./" + encodeURIComponent($(this).val().replace(/\//g, "-")) + "_cover." + title_dict[$(this).val()] + ".html";
+      let url = "./" + encodeURIComponent($(this).val().replace(/\//g, "-")) + "_cover." + title_dict[$(this).val()];
       $(location).attr("href", url);
     }
   });
@@ -832,7 +828,7 @@ function showLccShelfSearchResults(value) {
     $('#lccShelfTable tbody').on('click', 'tr', function() {
       let data = encodeURI($('span', this).attr('data-target'));
       console.log(data);
-      $(location).attr('href', './lcc_shelf_' + data + '.html');
+      $(location).attr('href', './lcc_shelf_' + data );
 
     });
     $("#lccShelfTable_previous").attr("data-l10n-id", "table-previous");

--- a/src/gutenberg2zim/utils.py
+++ b/src/gutenberg2zim/utils.py
@@ -26,7 +26,7 @@ def book_name_for_fs(book: Book) -> str:
 def article_name_for(book: Book, *, cover: bool = False) -> str:
     cover_suffix = "_cover" if cover else ""
     title = book_name_for_fs(book)
-    return f"{title}{cover_suffix}.{book.book_id}.html"
+    return f"{title}{cover_suffix}.{book.book_id}"
 
 
 def archive_name_for(book: Book, book_format: str) -> str:


### PR DESCRIPTION
Fix #166


Remove `.html` extension for:
- `Home.html` => `Home`
- `{book_title}_cover.{book_id}.html` => `{book_title}_cover.{book_id}` 
- `{book_title}.{book_id}.html` => `{book_title}.{book_id}`
- `{author_name}.{author_id}.html` => `{author_name}.{author_id}`
- `lcc_shelf_{lcc_id}.html` => `lcc_shelf_{lcc_id}`