### PR TITLE
Properly compute (including sorting) ZIM Language items + allow to override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ as of 2.0.0.
 - Fix navigation to bookshelves with special characters (#305)
 - Bookshelves with special characters cannot be opened (#306)
 - Fix internationalization of the "Copyrighted" license label (#253)
+- Properly compute (including sorting) ZIM Language items + allow to override with --zim-languages (#323)
 
 ## [2.2.0] - 2025-06-06
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can find the full arguments list below:
 -t --zim-title=<title>          Set ZIM title
 -n --zim-desc=<description>     Set ZIM description
 -L --zim-long-desc=<description> Set ZIM long description
+--zim-languages=<languages>          Set ZIM Language metadata
 -b --books=<ids>                Execute the processes for specific books, separated by commas, or dashes for intervals
 -c --concurrency=<nb>           Number of concurrent process for processing tasks
 --no-index                      Do NOT create full-text index within ZIM file

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -76,6 +76,14 @@
       "title": "Output folder",
       "description": "Output folder for ZIM file(s). Leave it as `/output`",
       "pattern": "^/output$"
+    },
+    "zim_languages": {
+      "type": "string",
+      "required": false,
+      "title": "ZIM Languages",
+      "description": "ZIM Language metadata; comma separated ISO-639-3 language codes expected",
+      "pattern": "^[a-z]{3}(,[a-z]{3})*$",
+      "customValidator": "language_code"
     }
   }
 }

--- a/src/gutenberg2zim/csv_catalog.py
+++ b/src/gutenberg2zim/csv_catalog.py
@@ -121,7 +121,7 @@ def filter_books(
     languages: list[str] | None = None,
     only_books: list[int] | None = None,
     lcc_shelves: list[str] | None = None,
-) -> list[int]:
+) -> list[CatalogEntry]:
     """
     Filter books based on languages, book IDs, and LCC shelves.
 
@@ -135,7 +135,7 @@ def filter_books(
     Returns:
         list: List of book IDs that match the filters
     """
-    filtered: list[int] = []
+    filtered: list[CatalogEntry] = []
 
     for entry in catalog:
         # Filter by specific book IDs if requested
@@ -156,7 +156,7 @@ def filter_books(
             if entry.lcc_shelf not in lcc_shelves:
                 continue
 
-        filtered.append(entry.book_id)
+        filtered.append(entry)
 
     logger.info(
         f"\tFiltered to {len(filtered)} books "

--- a/src/gutenberg2zim/iso639.py
+++ b/src/gutenberg2zim/iso639.py
@@ -232,3 +232,12 @@ ISO_MATRIX = {
 }
 
 ISO_MATRIX_REV = {value: key for key, value in ISO_MATRIX.items()}
+
+ZIM_LANGUAGES_MAP: dict[str, list[str]] = {
+    # no idea how to map `myn` and `nai` in ZIM Language metadata for now
+    # do not block if these are parts of another language but refuse to create ZIM
+    # if only this language is requested and --zim-lang is not passed
+    "myn": [],
+    "nai": [],
+    "nah": ["nhe"],
+}


### PR DESCRIPTION
Changes:
- properly pass list of ISO639-3 and sorted by importance languages to ZIM creator
- override some "bad" codes
- ignore `myn` and `nai` (see https://github.com/openzim/gutenberg/issues/322) codes for the time being
- add `--zim-languages` CLI argument to allow override the ZIM metadata if needed
- if `--language myn` is passed, it will be blocked (no matching ISO639-3 code) unless `--zim-languages` is passed with a "proper" (random? wrong?) value