### PR TITLE
Fix Kiwix-JS Restricted Mode: Remove meta refresh, use simple link in…

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -50,7 +50,7 @@
       </style>
       <div class="message">
         <h1>JavaScript is Disabled</h1>
-        <p>This application requires JavaScript to function. Please click the link below to access the No-JavaScript version:</p>
+        <p>The usual ZIM interface isn't available right now because JavaScript isn't running in your ZIM reader. You can still view the content by using the No-JavaScript version below:</p>
         <a href="./noscript/books.html">Go to No-JavaScript Version</a>
       </div>
     </noscript>


### PR DESCRIPTION
Following the recommendation from @Jaifroid, we implemented Option 1: removed the meta refresh tag entirely and replaced it with a simple link in the `<noscript>` block. This allows Kiwix-JS to properly intercept the link click using its existing `parseAnchorsJQuery()` mechanism.
Fixes #364 