### PR TITLE
Add CLI flags for primary and secondary color customization (#363)

### DIFF
--- a/GUTENBERG_STRUCTURE.md
+++ b/GUTENBERG_STRUCTURE.md
@@ -215,7 +215,7 @@ class Config(CamelModel):
     """UI configuration"""
     title: str
     description: str | None = None
-    mainColor: str | None = None
+    primaryColor: str | None = None
     secondaryColor: str | None = None
 ```
 
@@ -375,7 +375,7 @@ class Config(CamelModel):
 {
   "title": "Project Gutenberg Library",
   "description": "Free eBooks from Project Gutenberg",
-  "mainColor": null,
+  "primaryColor": null,
   "secondaryColor": null
 }
 ```

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -118,6 +118,20 @@
       "required": false,
       "title": "Mirror URL",
       "description": "URL to a specific Gutenberg mirror to use"
+    },
+    "primary_color": {
+      "type": "string",
+      "required": false,
+      "title": "Primary Color",
+      "description": "Custom primary color. Hex/HTML syntax (#1976D2)",
+      "pattern": "^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$"
+    },
+    "secondary_color": {
+      "type": "string",
+      "required": false,
+      "title": "Secondary Color",
+      "description": "Custom secondary color. Hex/HTML syntax (#424242)",
+      "pattern": "^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$"
     }
   }
 }

--- a/scraper/docs/JSON_FILE_STRUCTURE.md
+++ b/scraper/docs/JSON_FILE_STRUCTURE.md
@@ -247,7 +247,7 @@ ZIM_ROOT/
 {
   "title": "Project Gutenberg Library",
   "description": "Free eBooks from Project Gutenberg",
-  "mainColor": null,
+  "primaryColor": null,
   "secondaryColor": null
 }
 ```

--- a/scraper/src/gutenberg2zim/book_processor.py
+++ b/scraper/src/gutenberg2zim/book_processor.py
@@ -34,6 +34,8 @@ def process_all_books(
     add_lcc_shelves: bool,
     title: str | None = None,
     description: str | None = None,
+    primary_color: str | None = None,
+    secondary_color: str | None = None,
 ) -> None:
     """Download and export all books directly to ZIM without filesystem cache"""
 
@@ -153,6 +155,8 @@ def process_all_books(
         title=title,
         description=description,
         add_lcc_shelves=add_lcc_shelves,
+        primary_color=primary_color,
+        secondary_color=secondary_color,
     )
 
     # Generate No-JS fallback pages

--- a/scraper/src/gutenberg2zim/export.py
+++ b/scraper/src/gutenberg2zim/export.py
@@ -608,6 +608,8 @@ def generate_json_files(
     description: str | None = None,
     *,
     add_lcc_shelves: bool = False,
+    primary_color: str | None = None,
+    secondary_color: str | None = None,
 ) -> None:
     """Generate all JSON files for Vue.js frontend"""
     logger.info("Generating JSON files for Vue.js UI")
@@ -657,8 +659,8 @@ def generate_json_files(
     config = Config(
         title=title or zim_name or "Project Gutenberg Library",
         description=description,
-        main_color=None,
-        secondary_color=None,
+        primary_color=primary_color,
+        secondary_color=secondary_color,
     )
     Global.add_item_for(
         path="config.json",

--- a/scraper/src/gutenberg2zim/schemas.py
+++ b/scraper/src/gutenberg2zim/schemas.py
@@ -117,7 +117,7 @@ class Config(CamelModel):
 
     title: str
     description: str | None = None
-    main_color: str | None = None
+    primary_color: str | None = None
     secondary_color: str | None = None
 
 

--- a/scraper/src/gutenberg2zim/zim.py
+++ b/scraper/src/gutenberg2zim/zim.py
@@ -75,6 +75,8 @@ def build_zimfile(
     zim_languages: list[str] | None,
     publisher: str,
     *,
+    primary_color: str | None = None,
+    secondary_color: str | None = None,
     force: bool,
     is_selection: bool,
     title_search: bool,
@@ -148,6 +150,8 @@ def build_zimfile(
             add_lcc_shelves=add_lcc_shelves,
             title=title,
             description=description,
+            primary_color=primary_color,
+            secondary_color=secondary_color,
         )
 
         # Export Vue.js UI dist folder

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -11,7 +11,7 @@ async function loadVuetify() {
 
   try {
     const response = await axios.get<Config>('./config.json')
-    primaryColor = response.data.mainColor || primaryColor
+    primaryColor = response.data.primaryColor || primaryColor
     secondaryColor = response.data.secondaryColor || secondaryColor
   } catch (error) {
     console.warn('Failed to load config.json for theme colors, using defaults.', error)

--- a/ui/src/types/Config.ts
+++ b/ui/src/types/Config.ts
@@ -1,6 +1,6 @@
 export interface Config {
   title: string
   description: string | null
-  mainColor: string | null
+  primaryColor: string | null
   secondaryColor: string | null
 }


### PR DESCRIPTION
## Add CLI flags for primary and secondary color customization (#363)

### Summary
This PR implements CLI flags for customizing primary and secondary colors in the Gutenberg ZIM builds, making them more flexible and themable. The colors are stored in `config.json` and applied to the Vue.js UI theme.

### Changes

#### CLI Flags
- Added `--primary-color` and `--secondary-color` flags to `gutenberg2zim` command
- Colors accept hex format (e.g., `#1976D2`, `#424242`)
- Both flags are optional; if omitted, default colors are used

#### Backend Changes
- **`entrypoint.py`**: Added color argument parsing from CLI
- **`zim.py`**: Updated `build_zimfile()` to accept and pass color parameters
- **`book_processor.py`**: Updated `process_all_books()` to accept color parameters
- **`export.py`**: Updated `generate_json_files()` to accept colors and use them in `Config` generation
- **`schemas.py`**: Renamed `main_color` → `primary_color` in `Config` schema (Python snake_case, automatically converted to camelCase in JSON)

#### Frontend Changes
- **`Config.ts`**: Renamed `mainColor` → `primaryColor` in TypeScript interface
- **`vuetify.ts`**: Updated to read `primaryColor` from `config.json` instead of `mainColor`

#### Configuration
- **`offliner-definition.json`**: Added `primary_color` and `secondary_color` flag definitions for offliner integration

#### Documentation
- Updated `JSON_FILE_STRUCTURE.md` and `GUTENBERG_STRUCTURE.md` to reflect the rename from `mainColor` to `primaryColor`

### Usage Example
```bash
gutenberg2zim --books 1-30 --languages en,fr,es --lcc-shelves all \
  --primary-color "#1976D2" --secondary-color "#424242" \
  --ui-dist ./ui/dist --output ./output --force
```

**Note**: In PowerShell, color values must be quoted (e.g., `"#1976D2"`) because `#` is treated as a comment character.

### Testing
- ✅ Colors are correctly passed through the call chain
- ✅ Colors are stored in `config.json` with correct field names
- ✅ Vue.js UI correctly reads and applies custom colors
- ✅ Default colors are used when flags are omitted

### Related Issue
Fixes #363

<img width="944" height="474" alt="Screenshot 2025-12-13 073743" src="https://github.com/user-attachments/assets/6ea6486a-7dd8-432c-9f83-cf67c5499a16" />
