### PR TITLE
adapt flags to support color types

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -120,14 +120,14 @@
       "description": "URL to a specific Gutenberg mirror to use"
     },
     "primary_color": {
-      "type": "string",
+      "type": "color",
       "required": false,
       "title": "Primary Color",
       "description": "Custom primary color. Hex/HTML syntax (#1976D2)",
       "pattern": "^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$"
     },
     "secondary_color": {
-      "type": "string",
+      "type": "color",
       "required": false,
       "title": "Secondary Color",
       "description": "Custom secondary color. Hex/HTML syntax (#424242)",


### PR DESCRIPTION
## Rationale
See openzim/zimfarm#1573

## Changes
- change primary_color and secondary_color flags to color type
