### PR TITLE
refactor: make language and sort filters collapsible to save space

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -25,4 +25,5 @@ dist-ssr
 
 # TypeScript
 *.tsbuildinfo
+*.d.ts
 

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -7,7 +7,7 @@ export default [
   // Files linted: **/*.{js,mjs,cjs,ts,mts,tsx,vue}
   {
     name: 'app/files-to-ignore',
-    ignores: ['**/dist/**', '**/dist-ssr/**', '**/coverage/**'],
+    ignores: ['**/dist/**', '**/dist-ssr/**', '**/coverage/**', '**/*.d.ts'],
   },
 
   js.configs.recommended,

--- a/ui/src/components/common/BaseFilter.vue
+++ b/ui/src/components/common/BaseFilter.vue
@@ -18,12 +18,7 @@ const emit = defineEmits<{
 
 const { toggle, clearAll, selectAll } = useMultiSelectFilter(props, emit)
 
-function getIcon(item: string): string | undefined {
-  if (!props.iconMap) {
-    return undefined
-  }
-  return props.iconMap[item.toLowerCase()] || props.iconMap[item] || undefined
-}
+const getIcon = (item: string) => props.iconMap?.[item.toLowerCase()] ?? props.iconMap?.[item]
 </script>
 
 <template>
@@ -38,7 +33,6 @@ function getIcon(item: string): string | undefined {
           v-if="modelValue.length > 0"
           variant="text"
           size="small"
-          class="filter-action"
           @click="clearAll()"
           aria-label="Clear all selections"
         >
@@ -48,7 +42,6 @@ function getIcon(item: string): string | undefined {
           v-if="modelValue.length < items.length"
           variant="text"
           size="small"
-          class="filter-action"
           @click="selectAll(items)"
           aria-label="Select all"
         >
@@ -60,7 +53,7 @@ function getIcon(item: string): string | undefined {
     <v-divider />
 
     <v-card-text>
-      <v-chip-group multiple column role="group" aria-label="Filter options">
+      <v-chip-group multiple column>
         <v-chip
           v-for="item in items"
           :key="item"
@@ -91,34 +84,18 @@ function getIcon(item: string): string | undefined {
 <style scoped>
 .filter-header {
   display: flex;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
   gap: 8px;
-  line-height: 1.2;
 }
 
 .filter-title {
   display: flex;
   align-items: center;
-  min-width: 140px;
-  flex: 1 1 auto;
 }
 
 .filter-actions {
   display: flex;
-  flex-wrap: wrap;
   gap: 6px;
-  justify-content: flex-start;
-  flex: 1 1 auto;
-}
-
-.filter-action {
-  min-width: auto;
-  padding-inline: 12px;
-}
-
-@media (max-width: 640px) {
-  .filter-actions {
-    width: 100%;
-  }
 }
 </style>

--- a/ui/src/components/common/CollapsibleFilters.vue
+++ b/ui/src/components/common/CollapsibleFilters.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import LanguageFilter from './LanguageFilter.vue'
+import SortControl from './SortControl.vue'
+import type { SortOption, SortOrder } from '@/types'
+
+defineProps<{
+  languages: string[]
+  selectedLanguages: string[]
+  sortBy: SortOption
+  sortOrder: SortOrder
+}>()
+
+defineEmits<{
+  'update:selectedLanguages': [value: string[]]
+  'update:sortBy': [value: SortOption]
+  'update:sortOrder': [value: SortOrder]
+}>()
+
+const showLanguages = ref(false)
+const showSort = ref(false)
+
+function toggle(panel: 'languages' | 'sort') {
+  if (panel === 'languages') {
+    showLanguages.value = !showLanguages.value
+    if (showLanguages.value) showSort.value = false
+  } else {
+    showSort.value = !showSort.value
+    if (showSort.value) showLanguages.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="collapsible-filters">
+    <div class="filter-buttons">
+      <v-btn
+        :variant="showLanguages ? 'flat' : 'outlined'"
+        :color="showLanguages ? 'primary' : undefined"
+        :aria-expanded="showLanguages"
+        aria-label="Toggle language filter"
+        @click="toggle('languages')"
+      >
+        <v-icon icon="mdi-translate" />
+        <span class="ml-2">Languages</span>
+        <v-badge
+          v-if="selectedLanguages.length > 0"
+          :content="selectedLanguages.length"
+          color="primary"
+          inline
+          class="ml-2"
+        />
+      </v-btn>
+
+      <v-btn
+        :variant="showSort ? 'flat' : 'outlined'"
+        :color="showSort ? 'primary' : undefined"
+        :aria-expanded="showSort"
+        aria-label="Toggle sort options"
+        @click="toggle('sort')"
+      >
+        <v-icon icon="mdi-sort" />
+        <span class="ml-2">Sort</span>
+      </v-btn>
+    </div>
+
+    <v-expand-transition>
+      <language-filter
+        v-if="showLanguages"
+        :model-value="selectedLanguages"
+        :languages="languages"
+        class="mt-3"
+        @update:model-value="$emit('update:selectedLanguages', $event)"
+      />
+    </v-expand-transition>
+
+    <v-expand-transition>
+      <sort-control
+        v-if="showSort"
+        :sort-by="sortBy"
+        :sort-order="sortOrder"
+        class="mt-3"
+        @update:sort-by="$emit('update:sortBy', $event)"
+        @update:sort-order="$emit('update:sortOrder', $event)"
+      />
+    </v-expand-transition>
+  </div>
+</template>
+
+<style scoped>
+.filter-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+</style>

--- a/ui/src/views/HomeView.vue
+++ b/ui/src/views/HomeView.vue
@@ -4,8 +4,7 @@ import { useMainStore } from '@/stores/main'
 import type { BookPreview, SortOption, SortOrder } from '@/types'
 import BookGrid from '@/components/book/BookGrid.vue'
 import BookList from '@/components/book/BookList.vue'
-import LanguageFilter from '@/components/common/LanguageFilter.vue'
-import SortControl from '@/components/common/SortControl.vue'
+import CollapsibleFilters from '@/components/common/CollapsibleFilters.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import PaginationControl from '@/components/common/PaginationControl.vue'
@@ -97,19 +96,8 @@ onMounted(() => {
       </v-row>
 
       <v-row v-else-if="books.length > 0">
-        <v-col cols="12" md="3">
-          <div class="filters-sidebar">
-            <language-filter
-              v-model="selectedLanguages"
-              :languages="availableLanguages"
-              class="mb-4"
-            />
-            <sort-control v-model:sort-by="sortBy" v-model:sort-order="sortOrder" />
-          </div>
-        </v-col>
-
-        <v-col cols="12" md="9">
-          <div class="d-flex justify-space-between align-center mb-4">
+        <v-col cols="12">
+          <div class="d-flex justify-space-between align-center mb-4 flex-wrap gap-3">
             <item-count :current="paginatedBooks.length" :total="sortedBooks.length" type="books" />
             <div class="d-flex align-center gap-2">
               <v-btn-toggle v-model="viewMode" mandatory variant="outlined" density="compact">
@@ -118,6 +106,14 @@ onMounted(() => {
               </v-btn-toggle>
             </div>
           </div>
+
+          <collapsible-filters
+            :languages="availableLanguages"
+            v-model:selected-languages="selectedLanguages"
+            v-model:sort-by="sortBy"
+            v-model:sort-order="sortOrder"
+            class="mb-4"
+          />
 
           <book-grid v-if="viewMode === 'grid'" :books="paginatedBooks" />
           <book-list v-else :books="paginatedBooks" />
@@ -145,17 +141,7 @@ onMounted(() => {
   padding: v-bind('LAYOUT.VIEW_PADDING');
 }
 
-.filters-sidebar {
-  position: sticky;
-  top: 80px;
-}
-
 @media (max-width: 960px) {
-  .filters-sidebar {
-    position: static;
-    margin-bottom: v-bind('LAYOUT.SIDEBAR_MARGIN_MOBILE');
-  }
-
   .home-view {
     padding: v-bind('LAYOUT.VIEW_PADDING_MOBILE');
   }

--- a/ui/vitest.config.d.ts
+++ b/ui/vitest.config.d.ts
@@ -1,2 +1,0 @@
-declare const _default: Record<string, unknown>
-export default _default


### PR DESCRIPTION
This PR addresses issue #389 by making the language and sort filters collapsible, significantly reducing the visual space they occupy.

## Changes

### UI Improvements
- Replaced the sticky sidebar layout with collapsible filter buttons
- Filters are now hidden by default and expand when clicked
- Language filter button shows a badge with the count of active filters
- Only one filter panel can be open at a time for cleaner UX

### Build Fixes
- Added `**/*.d.ts` to ESLint ignore patterns
- Added `*.d.ts` to `.gitignore` to prevent committing auto-generated TypeScript declaration files

## Before/After

**Before:** Language and Sort filters took up the entire left sidebar (3 columns on desktop), always visible
<img width="956" height="479" alt="Screenshot 2026-02-13 115821" src="https://github.com/user-attachments/assets/35808a51-9c3e-4a2b-893c-a9fdb219a1b7" />


**After:** Filters are hidden behind two compact buttons, expanding inline only when needed
<img width="866" height="425" alt="Screenshot 2026-02-13 124154" src="https://github.com/user-attachments/assets/23729856-41f9-4b20-8915-55993fbce426" />
<img width="707" height="402" alt="Screenshot 2026-02-13 124135" src="https://github.com/user-attachments/assets/4420673d-b444-4045-870d-c53b52ed46e9" />
<img width="715" height="334" alt="Screenshot 2026-02-13 135628" src="https://github.com/user-attachments/assets/1f4cedf1-5b69-42ca-93f4-3ad94eec205f" />


This makes the UI cleaner and gives more space to the book grid, especially since these filters are rarely used.