### PR TITLE
Ensure reasonable access to books when JavaScript is disabled

### DIFF
--- a/scraper/src/gutenberg2zim/export.py
+++ b/scraper/src/gutenberg2zim/export.py
@@ -575,16 +575,20 @@ def _lcc_shelf_to_preview(shelf_code: str) -> LCCShelfPreview:
     )
 
 
-def add_index_entry(title: str, content: str, fname: str, vue_route: str) -> None:
-    """Add a custom item to the ZIM index with HTML redirect to Vue.js route.
+def add_index_entry(title: str, content: str, fname: str) -> None:
+    """Add a custom item to the ZIM index with HTML redirect to no-JS fallback page.
+
+    Search results (title search, full-text) must work without JavaScript. Index
+    entries redirect to noscript pages so both JS and no-JS users can access
+    content when clicking search results.
 
     Args:
         title: Title for the index entry
         content: Content/description for search indexing
-        fname: Filename for the index entry (e.g., "book_12345")
-        vue_route: Vue.js route path (e.g., "book/12345")
+        fname: Filename for the index entry (e.g., "book_12345") - must match
+            the noscript page name (e.g., noscript/book_12345.html)
     """
-    redirect_url = f"../index.html#/{vue_route}"
+    redirect_url = f"../noscript/{fname}.html"
     html_content = (
         f"<html><head><title>{title}</title>"
         f'<meta http-equiv="refresh" content="0;URL=\'{redirect_url}\'" />'
@@ -686,7 +690,6 @@ def generate_json_files(
             title=book.title,
             content=book_description,
             fname=f"book_{book.book_id}",
-            vue_route=f"book/{book.book_id}",
         )
 
     logger.debug("Generating author detail files and index entries")
@@ -730,7 +733,6 @@ def generate_json_files(
             title=author.name(),
             content=author_content,
             fname=f"author_{author.gut_id}",
-            vue_route=f"author/{author.gut_id}",
         )
 
     if add_lcc_shelves:
@@ -764,7 +766,6 @@ def generate_json_files(
                 title=shelf_title,
                 content=shelf_content,
                 fname=f"lcc_shelf_{shelf_code}",
-                vue_route=f"lcc-shelf/{shelf_code}",
             )
 
     logger.info("JSON file generation completed")

--- a/scraper/src/gutenberg2zim/templates/book_infobox.html
+++ b/scraper/src/gutenberg2zim/templates/book_infobox.html
@@ -1,6 +1,6 @@
 <div id="gutenberg-infobox">
     <a 
-        href="./index.html#/book/{{ book.book_id }}" 
+        href="./noscript/book_{{ book.book_id }}.html" 
         class="gutenberg-btn gutenberg-btn-info" 
         aria-label="View book cover and information"
         title="View book cover and information"

--- a/scraper/src/gutenberg2zim/templates/noscript/_nav.html
+++ b/scraper/src/gutenberg2zim/templates/noscript/_nav.html
@@ -3,5 +3,6 @@
     <a href="books.html">Books</a>
     <a href="authors.html">Authors</a>
     <a href="lcc_shelves.html">Shelves</a>
+    <a href="../index.html">View in full interface</a>
 </div>
 


### PR DESCRIPTION
### Summary
Project already has `noscript` pages for books, authors, and navigation, but some entry points still redirected to Vue routes, which do not work when JavaScript is disabled. So, some search results and navigation paths were unusable for no-JS users.

This PR ensures consistent access to books without JavaScript by redirecting search index entries and book information links to the corresponding `noscript` pages, making search, browsing, and reading flows usable without JavaScript.

### Fixes #345

### Changes
- Update `add_index_entry()` to redirect to noscript pages
- Remove unused `vue_route` parameter
- Add "View in full interface" link to noscript navigation
- Update book infobox link to point to noscript book pages instead of Vue routes

### Outcome
- Title and full-text search work without JavaScript
- Books, authors, and formats remain accessible via noscript pages
- Book information links while reading also work without JavaScript
- No-JS access is now consistent across search, browsing, and reading flows