### PR TITLE
Update to Python 3.14, Node.js 24, and upgrade dependencies

### DIFF
--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -11,10 +11,10 @@ jobs:
       id-token: write  # mandatory for PyPI trusted publishing
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: scraper/pyproject.toml
           architecture: x64
@@ -26,7 +26,7 @@ jobs:
           python -m build --sdist --wheel
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.12
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Build and push Docker image
         uses: openzim/docker-publish-action@v10

--- a/.github/workflows/PublishDockerDevImage.yaml
+++ b/.github/workflows/PublishDockerDevImage.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build and push Docker image
         uses: openzim/docker-publish-action@v10

--- a/.github/workflows/QA.yaml
+++ b/.github/workflows/QA.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: scraper/pyproject.toml
           architecture: x64
@@ -41,12 +41,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version-file: 'ui/package.json'
 
       - name: Install JS dependencies
         working-directory: ui

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -10,10 +10,10 @@ jobs:
   test-scraper:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: scraper/pyproject.toml
           architecture: x64
@@ -36,10 +36,10 @@ jobs:
   build-scraper:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: scraper/pyproject.toml
           architecture: x64
@@ -53,12 +53,12 @@ jobs:
   build-and-test-zimui:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version-file: 'ui/package.json'
 
       - name: Install dependencies
         working-directory: ui
@@ -87,7 +87,7 @@ jobs:
   build_docker:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Ensure we can build the Docker image
         run: |

--- a/.github/workflows/update-zim-offliner-definition.yaml
+++ b/.github/workflows/update-zim-offliner-definition.yaml
@@ -22,7 +22,7 @@ jobs:
       offliner_definition_b64: ${{ steps.read-json.outputs.offliner_definition_b64 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS ui
+FROM node:24-alpine AS ui
 
 WORKDIR /src
 COPY locales /locales
@@ -6,7 +6,7 @@ COPY ui /src
 RUN yarn install --frozen-lockfile || npm install
 RUN yarn build || npm run build
 
-FROM python:3.13.2-bookworm
+FROM python:3.14-bookworm
 
 LABEL org.opencontainers.image.source="https://github.com/openzim/gutenberg"
 

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -6,42 +6,42 @@ build-backend = "hatchling.build"
 name = "gutenberg2zim"
 authors = [{ name = "Kiwix", email = "dev@kiwix.org" }]
 keywords = ["kiwix", "zim", "offline", "gutenberg"]
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.14,<3.15"
 description = "Make ZIM file from Gutenberg books"
 readme = "../README.md"
 license = { text = "GPL-3.0-or-later" }
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
 ]
 dependencies = [
-  "beautifulsoup4==4.14.2",
+  "beautifulsoup4==4.14.3",
   "Jinja2==3.1.6",
   "path.py==12.5.0",
-  "Babel==2.17.0",
+  "Babel==2.18.0",
   "lxml==6.0.2",
   "docopt==0.6.2",
   "chardet==5.2.0",
-  "apsw==3.50.4.0",
-  "kiwixstorage==0.9.0",
+  "apsw==3.51.2.0",
+  "kiwixstorage==0.10.1",
   "requests==2.32.5",
   "pif==0.8.2",
-  "zimscraperlib==5.2.0",
+  "zimscraperlib==5.3.0",
   "schedule==1.2.2",
   "backoff==2.2.1",
   "i18nice==0.16.0",
-  "pydantic==2.11.7",
+  "pydantic==2.12.5",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 scripts = ["invoke==2.2.1"]
-lint = ["black==25.9.0", "ruff==0.14.0"]
-check = ["pyright==1.1.406"]
-test = ["pytest==8.4.2", "coverage==7.10.7"]
+lint = ["black==25.12.0", "ruff==0.15.0"]
+check = ["pyright==1.1.408"]
+test = ["pytest==9.0.2", "coverage==7.13.4"]
 dev = [
-  "pre-commit==4.3.0",
+  "pre-commit==4.5.1",
   "debugpy==1.8.17",
   "ipdb==0.13.13",
   "ipython==9.6.0",
@@ -82,7 +82,7 @@ html = "inv coverage --html --args '{args}'"
 
 [tool.hatch.envs.lint]
 template = "lint"
-python = "py313"
+python = "py314"
 skip-install = false
 features = ["scripts", "lint"]
 
@@ -103,10 +103,10 @@ all = "inv checkall --args '{args}'"
 
 [tool.black]
 line-length = 88
-target-version = ['py313']
+target-version = ['py314']
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py314"
 line-length = 88
 src = ["src"]
 
@@ -227,6 +227,6 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 include = ["src", "tests", "tasks.py"]
 exclude = ["**/node_modules", "**/__pycache__", "src/gutenberg2zim/templates"]
 extraPaths = ["src"]
-pythonVersion = "3.13"
+pythonVersion = "3.14"
 pythonPlatform = "All"
 typeCheckingMode = "basic"

--- a/scraper/src/gutenberg2zim/export.py
+++ b/scraper/src/gutenberg2zim/export.py
@@ -73,7 +73,7 @@ jinja_env.filters["urlencode"] = urlencode
 jinja_env.filters["article_name_for"] = lambda book, cover=False: article_name_for(
     book, cover=cover
 )
-jinja_env.filters["archive_name_for"] = lambda book, fmt: archive_name_for(book, fmt)
+jinja_env.filters["archive_name_for"] = archive_name_for
 
 
 def html_content_for(book: Book, src_dir):

--- a/scraper/src/gutenberg2zim/models.py
+++ b/scraper/src/gutenberg2zim/models.py
@@ -107,7 +107,7 @@ class Book:
 class BookRepository:
     """In-memory repository for books and authors (Singleton)"""
 
-    _instance: "BookRepository | None" = None
+    _instance: BookRepository | None = None
 
     def __new__(cls):
         if cls._instance is None:
@@ -130,7 +130,7 @@ class BookRepository:
         self.authors["216"] = Author(gut_id="216", last_name="Anonymous")
 
     @classmethod
-    def get_instance(cls) -> "BookRepository":
+    def get_instance(cls) -> BookRepository:
         """Get the singleton instance of BookRepository"""
         if cls._instance is None:
             cls._instance = cls()

--- a/scraper/src/gutenberg2zim/schemas.py
+++ b/scraper/src/gutenberg2zim/schemas.py
@@ -40,7 +40,7 @@ class AuthorDetail(AuthorPreview):
     last_name: str
     birth_year: str | None = None
     death_year: str | None = None
-    books: list["BookPreview"]
+    books: list[BookPreview]
 
 
 # Book Models
@@ -57,7 +57,7 @@ class BookPreview(CamelModel):
 
     id: int
     title: str
-    author: "AuthorPreview"
+    author: AuthorPreview
     languages: list[str]
     popularity: int  # Star rating (0-5)
     cover_path: str | None = None
@@ -70,7 +70,7 @@ class Book(BookPreview):
     subtitle: str | None = None
     license: str
     downloads: int
-    author: "Author"
+    author: Author
     formats: list[BookFormat]
     description: str | None = None  # If available from RDF
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,6 @@
         "axios": "^1.13.5",
         "pinia": "^3.0.4",
         "resize-observer-polyfill": "^1.5.1",
-        "vite-plugin-vuetify": "^2.1.3",
         "vue": "^3.5.28",
         "vue-i18n": "^11.2.8",
         "vue-router": "^5.0.2",
@@ -20,9 +19,9 @@
       },
       "devDependencies": {
         "@mdi/font": "^7.4.47",
-        "@tsconfig/node20": "^20.1.9",
+        "@tsconfig/node24": "^24.0.0",
         "@types/jsdom": "^27.0.0",
-        "@types/node": "^25.2.3",
+        "@types/node": "^24.0.0",
         "@vitejs/plugin-legacy": "^7.2.1",
         "@vitejs/plugin-vue": "^6.0.4",
         "@vue/eslint-config-prettier": "^10.2.0",
@@ -37,8 +36,12 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.55.0",
         "vite": "^7.3.1",
+        "vite-plugin-vuetify": "^2.1.3",
         "vitest": "^4.0.18",
         "vue-tsc": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=24.0.0 <25.0.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -1765,6 +1768,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1781,6 +1785,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1797,6 +1802,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1813,6 +1819,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1829,6 +1836,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1845,6 +1853,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1861,6 +1870,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1877,6 +1887,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1893,6 +1904,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1909,6 +1921,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1925,6 +1938,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1941,6 +1955,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1957,6 +1972,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1973,6 +1989,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1989,6 +2006,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2005,6 +2023,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2021,6 +2040,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2037,6 +2057,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,6 +2074,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2069,6 +2091,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2085,6 +2108,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2101,6 +2125,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2117,6 +2142,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2133,6 +2159,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2149,6 +2176,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,6 +2193,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2527,7 +2556,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2602,6 +2631,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2615,6 +2645,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2628,6 +2659,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2641,6 +2673,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2654,6 +2687,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2667,6 +2701,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2680,6 +2715,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2693,6 +2729,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2706,6 +2743,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2719,6 +2757,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2732,6 +2771,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2745,6 +2785,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2758,6 +2799,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2771,6 +2813,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2784,6 +2827,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2797,6 +2841,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2810,6 +2855,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2823,6 +2869,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2836,6 +2883,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2849,6 +2897,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2862,6 +2911,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2875,6 +2925,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2888,6 +2939,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,6 +2953,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2914,6 +2967,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2927,10 +2981,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+    "node_modules/@tsconfig/node24": {
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
+      "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2956,6 +3010,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {
@@ -2978,10 +3033,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
-      "devOptional": true,
+      "version": "24.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -3700,6 +3755,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-2.1.2.tgz",
       "integrity": "sha512-X+1jBLmXHkpQEnC0vyOb4rtX2QSkBiFhaFXz8yhQqN2A4vQ6k2nChxN4Ol7VAY5KoqMdFoRMnmNdp/1qYXDQig==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "upath": "^2.0.1"
@@ -4022,7 +4078,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
@@ -4317,6 +4373,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4505,6 +4562,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5023,6 +5081,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5779,6 +5838,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {
@@ -6421,6 +6481,7 @@
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -6550,7 +6611,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6569,7 +6630,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -6788,7 +6849,7 @@
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -6807,7 +6868,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -7012,7 +7073,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -7117,6 +7178,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
       "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4",
@@ -7175,6 +7237,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -7249,6 +7312,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/vite-plugin-vuetify/-/vite-plugin-vuetify-2.1.3.tgz",
       "integrity": "sha512-Q4SC/4TqbNvaZIFb9YsfBqkGlYHbJJJ6uU3CnRBZqLUF3s5eCMVZAaV4GkTbehIH/bhSj42lMXztOwc71u6rVw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vuetify/loader-shared": "^2.1.2",
@@ -7268,6 +7332,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -7285,6 +7350,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=24.0.0 <25.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
@@ -25,9 +28,9 @@
   },
   "devDependencies": {
     "@mdi/font": "^7.4.47",
-    "@tsconfig/node20": "^20.1.9",
+    "@tsconfig/node24": "^24.0.0",
     "@types/jsdom": "^27.0.0",
-    "@types/node": "^25.2.3",
+    "@types/node": "^24.0.0",
     "@vitejs/plugin-legacy": "^7.2.1",
     "@vitejs/plugin-vue": "^6.0.4",
     "@vue/eslint-config-prettier": "^10.2.0",

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node24/tsconfig.json",
   "include": [
     "vite.config.*",
     "vitest.config.*",


### PR DESCRIPTION
## Update to Python 3.14, Node.js 24, and upgrade dependencies

Runtime Updates:
- Python: 3.13 to 3.14 in `Dockerfile` and `pyproject.toml`
- Node.js: 20 to 24 in `Dockerfile`
- Base images: `python:3.14-bookworm`, `node:24-alpine`

GitHub Actions:
- Update actions to latest major versions (v6)
- Use `node-version-file` instead of hardcoded versions
- Add Node.js engine specification in `package.json`


>Note: Black 26.1.0 has a bug with except statement syntax. Kept 25.12.0 for now.

Fixes #401 