### PR TITLE
Fix misleading infobox assets

### DIFF
--- a/scraper/src/gutenberg2zim/book_processor.py
+++ b/scraper/src/gutenberg2zim/book_processor.py
@@ -43,10 +43,6 @@ def process_all_books(
         f"Processing {len(book_ids)} books with {concurrency} (parallel) worker(s)"
     )
 
-    # Export infobox assets (CSS, JS, and icons)
-    logger.info("Exporting infobox assets")
-    export_infobox_assets()
-
     def backoff_busy_error_hdlr(details):
         logger.warning(
             "Backing off {wait:0.1f} seconds after {tries} tries "
@@ -121,6 +117,10 @@ def process_all_books(
             )
 
     Pool(concurrency).map(partial(process_book, progress=progress), book_ids)
+
+    # Export infobox assets (CSS, JS, and icons)
+    logger.info("Exporting infobox assets")
+    export_infobox_assets()
 
     # Compute popularity (a bit too late for rendering on books pages,
     # but still useful for sorting)


### PR DESCRIPTION
## Fix misleading infobox assets log timing
Fixes #400

The log output was misleading about timing:

```
INFO:Processing 5 books with 16 (parallel) worker(s)
INFO:Exporting infobox assets
[40 seconds pass]
INFO:Computing book popularity
```
This made it appear that "Exporting infobox assets" took 40 seconds, when in reality it was the parallel book processing that took that time.

**Solution :**
Moved the "Exporting infobox assets" log to appear after the Pool.map() completes:


```
INFO:Processing 5 books with 16 (parallel) worker(s)
[40 seconds pass - book processing]
INFO:Exporting infobox assets
INFO:Computing book popularity
```