### PR TITLE
Rename cover_page to has_cover and change type to bool

### DIFF
--- a/scraper/src/gutenberg2zim/download.py
+++ b/scraper/src/gutenberg2zim/download.py
@@ -187,7 +187,7 @@ def download_book(
         return None
 
     # download cover image
-    if book.cover_page:
+    if book.has_cover:
         url = (
             f"{mirror_url}/cache/epub/{book.book_id}/pg{book.book_id}.cover.medium.jpg"
         )

--- a/scraper/src/gutenberg2zim/export.py
+++ b/scraper/src/gutenberg2zim/export.py
@@ -505,7 +505,7 @@ def _author_to_schema(author: Author) -> AuthorSchema:
 
 def _book_to_preview(book: Book) -> BookPreview:
     """Convert Book dataclass to BookPreview schema"""
-    cover_path = f"covers/{book.book_id}_cover_image.jpg" if book.cover_page else None
+    cover_path = f"covers/{book.book_id}_cover_image.jpg" if book.has_cover else None
 
     return BookPreview(
         id=book.book_id,
@@ -520,7 +520,7 @@ def _book_to_preview(book: Book) -> BookPreview:
 
 def _book_to_schema(book: Book, formats: list[str]) -> BookSchema:
     """Convert Book dataclass to Book schema with formats"""
-    cover_path = f"covers/{book.book_id}_cover_image.jpg" if book.cover_page else None
+    cover_path = f"covers/{book.book_id}_cover_image.jpg" if book.has_cover else None
 
     book_formats: list[BookFormat] = []
     available_formats = book.requested_formats(formats)

--- a/scraper/src/gutenberg2zim/models.py
+++ b/scraper/src/gutenberg2zim/models.py
@@ -65,7 +65,7 @@ class Book:
     subtitle: str | None = None
     downloads: int = 0
     lcc_shelf: str | None = None
-    cover_page: int = 0
+    has_cover: bool = False
     unsupported_formats: list[str] = field(default_factory=list)
     popularity: int = 0  # Computed field for star rating
 

--- a/scraper/src/gutenberg2zim/rdf.py
+++ b/scraper/src/gutenberg2zim/rdf.py
@@ -20,7 +20,7 @@ class RdfParser:
 
         self.bookshelf = None
         self.lcc_shelf = None
-        self.cover_image = 0
+        self.has_cover = False
 
     def parse(self):
         soup = BeautifulSoup(self.rdf_data, "lxml-xml")
@@ -70,12 +70,8 @@ class RdfParser:
                     return True
             return False
 
-        self.cover_image = (
-            1
-            if any(
-                is_cover_node(file_node) for file_node in soup.find_all("pgterms:file")
-            )
-            else 0
+        self.has_cover = any(
+            is_cover_node(file_node) for file_node in soup.find_all("pgterms:file")
         )
 
         # Parsing the name of the Author. Sometimes it's the name of
@@ -190,7 +186,7 @@ def _save_rdf_in_repository(parser: RdfParser) -> None:
         license=parser.license,
         downloads=int(parser.downloads),
         lcc_shelf=parser.lcc_shelf,
-        cover_page=parser.cover_image,
+        has_cover=parser.has_cover,
     )
     repository.add_book(book)
 

--- a/scraper/src/gutenberg2zim/templates/noscript/book.html
+++ b/scraper/src/gutenberg2zim/templates/noscript/book.html
@@ -14,7 +14,7 @@
     <div class="subtitle">{{ book.subtitle }}</div>
     {% endif %}
     
-        {% if book.cover_page %}
+    {% if book.has_cover %}
     <img src="../covers/{{ book.book_id }}_cover_image.jpg" alt="Cover: {{ book.title }}" class="cover-image">
     {% endif %}
     

--- a/scraper/tests/test_rdf.py
+++ b/scraper/tests/test_rdf.py
@@ -114,7 +114,7 @@ def test_rdf_parser():
     assert parsed.birth_year == "1806"
     assert parsed.author_id == "3485"
     assert parsed.bookshelf == "Category: Travel Writing"
-    assert parsed.cover_image == 1
+    assert parsed.has_cover
     assert parsed.death_year == "1851"
     assert parsed.downloads == "548"
     assert parsed.first_name == "James"
@@ -146,7 +146,7 @@ def test_rdf_parser_minimal():
     assert parsed.first_name is None
     assert parsed.last_name is None
     assert parsed.bookshelf is None
-    assert parsed.cover_image == 0
+    assert not parsed.has_cover
     assert parsed.birth_year is None
     assert parsed.death_year is None
     assert parsed.bookshelf is None
@@ -185,32 +185,32 @@ def test_rdf_parser_multi_languages():
     [
         pytest.param(
             "https://www.gutenberg.org/cache/epub/22094/pg22094.cover.medium.jpg",
-            1,
+            True,
             id="good",
         ),
         pytest.param(
             "https://www.gutenberg.org/cache/epub/22094/pg22094.cover.medium.png",
-            0,
+            False,
             id="bad_extension",
         ),
         pytest.param(
             "https://www.gutenberg.org/cache/epub/22094/pg1234.cover.medium.jpg",
-            0,
+            False,
             id="bad_pg_id",
         ),
         pytest.param(
             "https://www.gutenberg.org/cache/epub/12345/pg22094.cover.medium.jpg",
-            0,
+            False,
             id="bad_folder_id",
         ),
         pytest.param(
             "https://foo.org/cache/epub/22094/pg22094.cover.medium.jpg",
-            1,
+            True,
             id="good_mirror",
         ),
     ],
 )
-def test_rdf_parser_cover(cover_url: str, expected_cover: int):
+def test_rdf_parser_cover(cover_url: str, *, expected_cover: bool):
     rdf = RdfParser(
         f"""
   {RDF_HEADER}
@@ -236,7 +236,7 @@ def test_rdf_parser_cover(cover_url: str, expected_cover: int):
         22094,
     )
     parsed = rdf.parse()
-    assert parsed.cover_image == expected_cover
+    assert parsed.has_cover == expected_cover
 
 
 def test_rdf_parser_title_subtitle():


### PR DESCRIPTION
Refactors the `Book.cover_page` field to improve code clarity and type correctness.

### Changes

- **Renamed** `cover_page` → `has_cover` (more descriptive name)
- **Changed type** from `int` (0/1) to `bool` (True/False)
- **Updated all references** across the codebase

### Files Modified

- `scraper/src/gutenberg2zim/models.py` - Field definition
- `scraper/src/gutenberg2zim/rdf.py` - Parser initialization and value assignment
- `scraper/src/gutenberg2zim/download.py` - Cover download condition
- `scraper/src/gutenberg2zim/export.py` - Book preview and schema generation
- `scraper/src/gutenberg2zim/templates/noscript/book.html` - Jinja2 template
- `scraper/tests/test_rdf.py` - Test assertions updated to use bool values

### Rationale

The `cover_page` field was:
- **Misleadingly named** - didn't clearly indicate it's a boolean flag
- **Wrong type** - stored as `int` (0/1) but used as boolean in all conditions
- **Inconsistent** - Python convention is to use `bool` for boolean values

This refactoring makes the code more Pythonic and easier to understand.

### Testing

- All 20 tests in `test_rdf.py` pass

Fixes #290
