### PR TITLE
Add Friulian (fur) language code mapping

### DIFF
--- a/scraper/src/gutenberg2zim/iso639.py
+++ b/scraper/src/gutenberg2zim/iso639.py
@@ -240,4 +240,5 @@ ZIM_LANGUAGES_MAP: dict[str, list[str]] = {
     "myn": [],
     "nai": [],
     "nah": ["nhe"],
+    "fur": ["fvr"],  # Friulian: IETF fur maps to ISO 639-3 fvr
 }


### PR DESCRIPTION
The Friulian language uses IETF code fur in Project Gutenberg, but ZIM files require ISO 639-3 code fvr. Without this mapping, Friulian ZIM files cannot be created properly.

Changes:
- Added Friulian language code mapping: fur (IETF) → fvr (ISO 639-3)
- Added inline comment explaining the mapping
Fixes #336 