### PR TITLE
Optimize ePub again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ as of 2.0.0.
 - Fix issue with i18n fallback language (#360)
 - Convert to WEBP and optimize WEBP, JPG and PNG images (both HTML resources + cover image) (#375)
 - Optimize Docker build topology to reuse layers (#420)
+- Optimize ePub again (#376)
 
 ## [3.0.1] - 2025-11-24
 

--- a/scraper/src/gutenberg2zim/export.py
+++ b/scraper/src/gutenberg2zim/export.py
@@ -1,5 +1,6 @@
 import io
 import urllib.parse
+import zipfile
 from collections.abc import Iterable
 from dataclasses import asdict
 from pathlib import Path
@@ -8,7 +9,11 @@ import bs4
 from bs4 import BeautifulSoup, Tag
 from jinja2 import Environment, PackageLoader
 from PIL.Image import open as pilopen
-from zimscraperlib.image.optimization import OptimizeWebpOptions
+from zimscraperlib.image.optimization import (
+    OptimizeWebpOptions,
+    optimize_jpeg,
+    optimize_png,
+)
 from zimscraperlib.zim.indexing import IndexData
 
 from gutenberg2zim.constants import logger
@@ -414,9 +419,12 @@ def handle_book_files(
             other_filenames.append(book_filename)
             try:
                 archive_name = archive_name_for(book, other_format)
+                content = book_files[book_filename]
+                if other_format == "epub":
+                    content = optimize_epub_bytes(content, book)
                 Global.add_item_for(
                     path=archive_name,
-                    content=book_files[book_filename],
+                    content=content,
                     is_front=False,
                 )
             except Exception as e:
@@ -483,6 +491,92 @@ def optimize_content(book: Book, filename: str, file_content: bytes) -> bytes:
         return file_content
     else:
         return file_content
+
+
+def _optimize_epub_jpeg(data: bytes) -> bytes:
+    """Optimize JPEG image in-memory for EPUB, keeping original format."""
+    dst = io.BytesIO()
+    optimize_jpeg(src=io.BytesIO(data), dst=dst)
+    return dst.getvalue()
+
+
+def _optimize_epub_png(data: bytes) -> bytes:
+    """Optimize PNG image in-memory for EPUB, keeping original format."""
+    dst = io.BytesIO()
+    optimize_png(src=io.BytesIO(data), dst=dst)
+    return dst.getvalue()
+
+
+def _process_epub_html(data: bytes, book: Book) -> bytes:
+    """Process HTML file from EPUB: remove Gutenberg markers and process content."""
+    html_str = data.decode("utf-8", errors="replace")
+    soup = update_html_for_static(
+        book=book, html_content=html_str, formats=[], epub=True
+    )
+    return str(soup).encode(UTF8)
+
+
+def _process_epub_ncx(data: bytes, book: Book | None = None) -> bytes:
+    """Process NCX navigation file: remove license section."""
+    ncx_str = data.decode("utf-8", errors="replace")
+    soup = BeautifulSoup(ncx_str, "lxml-xml")
+    pattern = "*** START: FULL LICENSE ***"
+    for tag in soup.find_all("text"):
+        if pattern in tag.text:
+            book_info = f"book {book.book_id}" if book else "unknown book"
+            logger.info(f"Found license section in NCX for {book_info}")
+            s = tag.parent.parent  # pyright: ignore[reportOptionalMemberAccess]
+            # Collect siblings before decomposing (decompose breaks iteration)
+            siblings_to_remove = list(
+                s.next_siblings  # pyright: ignore[reportOptionalMemberAccess]
+            )
+            s.decompose()  # pyright: ignore[reportOptionalMemberAccess]
+            for sibling in siblings_to_remove:
+                if hasattr(sibling, "decompose"):  # Skip text nodes
+                    sibling.decompose()
+            break
+    return str(soup).encode(UTF8)
+
+
+def optimize_epub_bytes(epub_bytes: bytes, book: Book) -> bytes:
+    """Optimize EPUB in-memory: process HTML/NCX and optimize images without FS."""
+    src_buf = io.BytesIO(epub_bytes)
+    dst_buf = io.BytesIO()
+    original_size = len(epub_bytes)
+
+    with (
+        zipfile.ZipFile(src_buf, "r") as src_zf,
+        zipfile.ZipFile(dst_buf, "w", zipfile.ZIP_DEFLATED) as dst_zf,
+    ):
+        for info in src_zf.infolist():
+            name = info.filename
+            data = src_zf.read(name)
+            suffix = Path(name).suffix.lower()
+
+            if suffix in (".jpg", ".jpeg"):
+                data = _optimize_epub_jpeg(data)
+            elif suffix == ".png":
+                data = _optimize_epub_png(data)
+            elif suffix in (".gif", ".webp"):
+                logger.warning(
+                    f"Unexpected {suffix} image in EPUB for book {book.book_id}: {name}"
+                )
+            elif suffix in (".htm", ".html"):
+                data = _process_epub_html(data, book)
+            elif suffix == ".ncx":
+                data = _process_epub_ncx(data, book)
+
+            dst_zf.writestr(info, data)
+
+    optimized_bytes = dst_buf.getvalue()
+    optimized_size = len(optimized_bytes)
+    if optimized_size > original_size:
+        logger.warning(
+            f"Optimized EPUB for book {book.book_id} is larger than original: "
+            f"{optimized_size} > {original_size} bytes"
+        )
+
+    return optimized_bytes
 
 
 def _lcc_shelf_list_for_books(books: Iterable[Book]):

--- a/scraper/src/gutenberg2zim/models.py
+++ b/scraper/src/gutenberg2zim/models.py
@@ -1,5 +1,7 @@
 """In-memory data models for Gutenberg books"""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 

--- a/scraper/tests/test_epub_optimization.py
+++ b/scraper/tests/test_epub_optimization.py
@@ -1,0 +1,137 @@
+"""Tests for EPUB optimization functions in export.py."""
+
+from types import SimpleNamespace
+
+import pytest
+from bs4 import BeautifulSoup
+
+from gutenberg2zim.export import _process_epub_html, _process_epub_ncx
+
+# Test data for NCX processing
+NCX_WITH_LICENSE = b"""<?xml version="1.0" encoding="utf-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <navMap>
+    <navPoint id="np1"><navLabel><text>Chapter 1</text></navLabel></navPoint>
+    <navPoint id="np2"><navLabel><text>Chapter 2</text></navLabel></navPoint>
+    <navPoint id="np3"><navLabel><text>*** START: FULL LICENSE ***</text></navLabel>
+    </navPoint>
+    <navPoint id="np4"><navLabel><text>License section</text></navLabel></navPoint>
+  </navMap>
+</ncx>"""
+
+NCX_WITHOUT_LICENSE = b"""<?xml version="1.0" encoding="utf-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <navMap>
+    <navPoint id="np1"><navLabel><text>Chapter 1</text></navLabel></navPoint>
+    <navPoint id="np2"><navLabel><text>Chapter 2</text></navLabel></navPoint>
+  </navMap>
+</ncx>"""
+
+# Test data for HTML processing
+HTML_WITH_LICENSE = b"""<html><body>
+<p>Gutenberg preamble (boilerplate)</p>
+<p>*** START OF THE PROJECT GUTENBERG EBOOK The Book</p>
+<p>Actual book content</p>
+<p>*** END OF THE PROJECT GUTENBERG EBOOK The Book</p>
+<p>Gutenberg postamble (boilerplate)</p>
+</body></html>"""
+
+HTML_WITHOUT_MARKERS = b"""<html><body>
+<p>Book content only, no markers</p>
+</body></html>"""
+
+HTML_WITH_CHARSET_META = b"""<html><head><meta charset="utf-8" /></head>
+<body><p>Content</p></body></html>"""
+
+HTML_WITH_IMG_SRC = b"""<html><body>
+<img src="images/foo.jpg" alt="test" />
+</body></html>"""
+
+
+class TestProcessEpubNcx:
+    """Test NCX file processing (_process_epub_ncx).
+
+    Note: The license section removal logic is kept for compatibility with
+    older EPUB files that may contain Gutenberg license markers in the NCX.
+    However, we don't have real examples of such files. When found, the app
+    will log the book ID for investigation (logger.info in _process_epub_ncx).
+    """
+
+    # TODO: Enable this test if/when we find a real EPUB with license in NCX
+    # def test_process_epub_ncx_removes_license_section(self):
+    #     """Verify that license section starting at marker is removed."""
+    #     result = _process_epub_ncx(NCX_WITH_LICENSE)
+    #     soup = BeautifulSoup(result, "lxml-xml")
+    #
+    #     # np3 and following elements should be removed
+    #     assert soup.find("navPoint", {"id": "np3"}) is None
+    #     # np1 and np2 should remain
+    #     assert soup.find("navPoint", {"id": "np1"}) is not None
+    #     assert soup.find("navPoint", {"id": "np2"}) is not None
+
+    def test_process_epub_ncx_no_license_unchanged(self):
+        """Verify that NCX without license markers is unchanged."""
+        result = _process_epub_ncx(NCX_WITHOUT_LICENSE)
+        soup = BeautifulSoup(result, "lxml-xml")
+
+        # All navPoints should remain
+        assert soup.find("navPoint", {"id": "np1"}) is not None
+        assert soup.find("navPoint", {"id": "np2"}) is not None
+
+    def test_process_epub_ncx_returns_bytes(self):
+        """Verify that result is bytes."""
+        result = _process_epub_ncx(NCX_WITHOUT_LICENSE)
+        assert isinstance(result, bytes)
+
+
+class TestProcessEpubHtml:
+    """Test HTML file processing (_process_epub_html)."""
+
+    @pytest.fixture
+    def book_stub(self):
+        """Create minimal book stub for HTML processing."""
+        return SimpleNamespace(
+            book_id=12345,
+            title="Test Book",
+            author=SimpleNamespace(name=lambda: "Test Author"),
+        )
+
+    def test_process_epub_html_removes_preamble_and_postamble(self, book_stub):
+        """Verify that Gutenberg preamble and postamble are removed."""
+        result = _process_epub_html(HTML_WITH_LICENSE, book_stub)
+        result_str = result.decode("utf-8")
+
+        # Preamble and postamble should be removed
+        assert "Gutenberg preamble" not in result_str
+        assert "Gutenberg postamble" not in result_str
+
+        # Book content should remain
+        assert "Actual book content" in result_str
+
+    def test_process_epub_html_no_markers_unchanged(self, book_stub):
+        """Verify that HTML without markers is preserved."""
+        result = _process_epub_html(HTML_WITHOUT_MARKERS, book_stub)
+        result_str = result.decode("utf-8")
+
+        assert "Book content only, no markers" in result_str
+
+    def test_process_epub_html_removes_charset_meta(self, book_stub):
+        """Verify that charset meta tag is removed."""
+        result = _process_epub_html(HTML_WITH_CHARSET_META, book_stub)
+        result_str = result.decode("utf-8")
+
+        # charset meta should be removed by update_html_for_static
+        assert 'charset="utf-8"' not in result_str
+
+    def test_process_epub_html_no_img_rewrite(self, book_stub):
+        """Verify that img src is not rewritten for EPUB (epub=True)."""
+        result = _process_epub_html(HTML_WITH_IMG_SRC, book_stub)
+        result_str = result.decode("utf-8")
+
+        # img src should NOT be rewritten (epub=True skips this)
+        assert "images/foo.jpg" in result_str
+
+    def test_process_epub_html_returns_bytes(self, book_stub):
+        """Verify that result is bytes."""
+        result = _process_epub_html(HTML_WITH_LICENSE, book_stub)
+        assert isinstance(result, bytes)


### PR DESCRIPTION
Fix #376

Changes:
- reimplement logic to optimize ePub like in logic removed by https://github.com/openzim/gutenberg/pull/300, but based on in-memory operations instead of file-based ones
- add unit-tests where possible
- NCX test case is not really known, so for the time being we display a log so we know if this logic is really useful
- add a warning log if optimized epub is bigger than original one
- optimize only JPG and PNG images, log a warning if another kind of image is found in the epub

Note that we do not convert images to webp (contrary to HTML images in https://github.com/openzim/gutenberg/pull/418) because webp is mostly unsupported by hardware epub readers (Kindle, Kobo, ...) so we keep original JPG and PNG files.