### PR TITLE
Add a function to remove MARC notations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ as of 2.0.0.
 
 ### Fixed
 
+- Add a function to remove MARC notations (#372)
 - Deduplicate cover images by reusing HTML version (#437)
 - Prevent crash when all books fail to download (#416)
 - Add Friulian (fur) language code mapping (#415)

--- a/scraper/src/gutenberg2zim/rdf.py
+++ b/scraper/src/gutenberg2zim/rdf.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import requests
@@ -25,11 +26,10 @@ class RdfParser:
     def parse(self):
         soup = BeautifulSoup(self.rdf_data, "lxml-xml")
 
-        # The tile of the book: this may or may not be divided
-        # into a new-line-seperated title and subtitle.
-        # If it is, then we will just split the title.
+        # Parse and clean the book title
+        # Title may be divided into newline-separated title and subtitle
         title = soup.find("dcterms:title")
-        full_title = title.text if title else "- No Title -"
+        full_title = clean_marc_notation(title.text) if title else "- No Title -"
         title_elements = full_title.split("\n")
         self.title = title_elements[0]
         self.subtitle = " ".join(title_elements[1:])
@@ -39,7 +39,7 @@ class RdfParser:
         if bookshelf_tag:
             rdf_value = bookshelf_tag.find("rdf:value")
             if isinstance(rdf_value, Tag):  # pragma: no branch
-                self.bookshelf = rdf_value.text
+                self.bookshelf = clean_marc_notation(rdf_value.text)
 
         # Parsing for the LoCC (Library of Congress Classification)
         # Transform it to a shelf identifier
@@ -96,7 +96,8 @@ class RdfParser:
 
             author_name_tag = author_tag.find("pgterms:name")
             if isinstance(author_name_tag, Tag):  # pragma: no branch
-                author_name_elements = author_name_tag.text.split(",")
+                author_name = clean_marc_notation(author_name_tag.text)
+                author_name_elements = author_name.split(",")
 
                 if len(author_name_elements) > 1:
                     self.first_name = " ".join(
@@ -137,6 +138,22 @@ class RdfParser:
             raise Exception(f"Impossible to find license tag in book {self.gid} RDF")
         self.license = license_tag.text
         return self
+
+
+def clean_marc_notation(text: str) -> str:
+    """
+    Remove MARC (Machine-Readable Cataloging) notation from text.
+
+    MARC uses subfield delimiters like $a, $b, $c, etc.
+    Example: "Peter Pan $b [Peter and Wendy]" -> "Peter Pan [Peter and Wendy]"
+
+    Args:
+        text: The text potentially containing MARC notation
+
+    Returns:
+        Text with MARC subfield delimiters removed
+    """
+    return re.sub(r"\$[a-z]\s*", "", text) if text else text
 
 
 def _save_rdf_in_repository(parser: RdfParser) -> None:

--- a/scraper/tests/test_rdf.py
+++ b/scraper/tests/test_rdf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gutenberg2zim.rdf import RdfParser
+from gutenberg2zim.rdf import RdfParser, clean_marc_notation
 
 RDF_HEADER = """
 <?xml version="1.0" encoding="utf-8"?>
@@ -105,6 +105,24 @@ HTML revised by David Widger</pgterms:marc508>
   </rdf:Description>
 </rdf:RDF>
 """  # noqa: E501
+
+
+@pytest.mark.parametrize(
+    "input_text, expected_output",
+    [
+        ("Peter Pan $b [Peter and Wendy]", "Peter Pan [Peter and Wendy]"),
+        ("Title $a Main $b Subtitle $c Edition", "Title Main Subtitle Edition"),
+        ("Normal Title Without MARC", "Normal Title Without MARC"),
+        ("Title$aNo Space", "TitleNo Space"),
+        ("Title $b  Extra Spaces", "Title Extra Spaces"),
+        ("", ""),
+        (None, None),
+        ("Price: $5.99", "Price: $5.99"),
+        ("Title $B uppercase", "Title $B uppercase"),
+    ],
+)
+def test_clean_marc_notation(input_text, expected_output):
+    assert clean_marc_notation(input_text) == expected_output
 
 
 def test_rdf_parser():


### PR DESCRIPTION
### Behavior 
The function removes MARC notation (:$a, :$b, etc.) and replaces it with ' : '

Fixes #372 