### PR TITLE
Fix language codes not recognized correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ as of 2.0.0.
 
 ### Fixed
 
+- Fix language codes not recognized correctly (#337)
 - Add a function to remove MARC notations (#372)
 - Deduplicate cover images by reusing HTML version (#437)
 - Prevent crash when all books fail to download (#416)

--- a/scraper/src/gutenberg2zim/iso639.py
+++ b/scraper/src/gutenberg2zim/iso639.py
@@ -240,5 +240,6 @@ ZIM_LANGUAGES_MAP: dict[str, list[str]] = {
     "myn": [],
     "nai": [],
     "nah": ["nhe"],
+    "nap": ["nap"],  # Neapolitan: no ISO 639-1 code, already valid ISO 639-3
     "fur": ["fvr"],  # Friulian: IETF fur maps to ISO 639-3 fvr
 }

--- a/scraper/src/gutenberg2zim/zim.py
+++ b/scraper/src/gutenberg2zim/zim.py
@@ -13,12 +13,27 @@ from gutenberg2zim.utils import get_zim_name
 
 
 def get_zim_language_metadata(languages: list[str], books: list[CatalogEntry]):
-    language_counts = {
-        zim_lang: sum(lang in book.languages for book in books)
-        for lang in languages
-        for zim_lang in ZIM_LANGUAGES_MAP.get(lang, [ISO_MATRIX.get(lang, None)])
-        if zim_lang
-    }
+    unresolved = []
+    language_counts: dict[str, int] = {}
+    for lang in languages:
+        zim_langs = ZIM_LANGUAGES_MAP.get(
+            lang,
+            # Try ISO_MATRIX (2-letter → 3-letter), fall back to
+            # ISO_MATRIX_REV to check if already a valid 3-letter code
+            [ISO_MATRIX.get(lang, lang if lang in ISO_MATRIX_REV else None)],
+        )
+        resolved = [zl for zl in zim_langs if zl]
+        if not resolved:
+            unresolved.append(lang)
+            continue
+        for zim_lang in resolved:
+            language_counts[zim_lang] = sum(lang in book.languages for book in books)
+    if unresolved:
+        logger.warning(
+            f"Could not resolve ZIM language metadata for: {', '.join(unresolved)}. "
+            "Books with these languages will still be included, but they won't appear "
+            "in ZIM language metadata."
+        )
     return sorted(language_counts, key=lambda lang: language_counts[lang], reverse=True)
 
 
@@ -123,9 +138,17 @@ def build_zimfile(
         logger.info(f"Removing existing ZIM file {zim_file}")
         zim_path.unlink(missing_ok=True)
 
+    resolved_languages = zim_languages or get_zim_language_metadata(languages, books)
+    if not resolved_languages:
+        raise ValueError(
+            f"Cannot resolve language metadata for: "
+            f"{', '.join(languages)}. "
+            "Use --zim-languages to override."
+        )
+
     Global.setup(
         filename=zim_path,
-        language=zim_languages or get_zim_language_metadata(languages, books),
+        language=resolved_languages,
         title=title,
         description=description,
         long_description=long_description,

--- a/scraper/src/gutenberg2zim/zim.py
+++ b/scraper/src/gutenberg2zim/zim.py
@@ -12,28 +12,30 @@ from gutenberg2zim.shared import Global
 from gutenberg2zim.utils import get_zim_name
 
 
-def get_zim_language_metadata(languages: list[str], books: list[CatalogEntry]):
-    unresolved = []
-    language_counts: dict[str, int] = {}
-    for lang in languages:
-        zim_langs = ZIM_LANGUAGES_MAP.get(
+def resolve_language(lang: str) -> list[str]:
+    """Helper to resolve one input language code to ZIM language code(s)."""
+    return [
+        zim_lang
+        for zim_lang in ZIM_LANGUAGES_MAP.get(
             lang,
-            # Try ISO_MATRIX (2-letter → 3-letter), fall back to
-            # ISO_MATRIX_REV to check if already a valid 3-letter code
             [ISO_MATRIX.get(lang, lang if lang in ISO_MATRIX_REV else None)],
         )
-        resolved = [zl for zl in zim_langs if zl]
-        if not resolved:
-            unresolved.append(lang)
-            continue
-        for zim_lang in resolved:
-            language_counts[zim_lang] = sum(lang in book.languages for book in books)
+        if zim_lang
+    ]
+
+
+def get_zim_language_metadata(languages: list[str], books: list[CatalogEntry]):
+    unresolved = [lang for lang in languages if not resolve_language(lang)]
     if unresolved:
-        logger.warning(
-            f"Could not resolve ZIM language metadata for: {', '.join(unresolved)}. "
-            "Books with these languages will still be included, but they won't appear "
-            "in ZIM language metadata."
+        raise ValueError(
+            f"Cannot resolve ZIM language metadata for: {', '.join(unresolved)}. "
+            "Use --zim-languages to override."
         )
+    language_counts = {
+        zim_lang: sum(lang in book.languages for book in books)
+        for lang in languages
+        for zim_lang in resolve_language(lang)
+    }
     return sorted(language_counts, key=lambda lang: language_counts[lang], reverse=True)
 
 
@@ -138,17 +140,9 @@ def build_zimfile(
         logger.info(f"Removing existing ZIM file {zim_file}")
         zim_path.unlink(missing_ok=True)
 
-    resolved_languages = zim_languages or get_zim_language_metadata(languages, books)
-    if not resolved_languages:
-        raise ValueError(
-            f"Cannot resolve language metadata for: "
-            f"{', '.join(languages)}. "
-            "Use --zim-languages to override."
-        )
-
     Global.setup(
         filename=zim_path,
-        language=resolved_languages,
+        language=zim_languages or get_zim_language_metadata(languages, books),
         title=title,
         description=description,
         long_description=long_description,

--- a/scraper/tests/test_zim_language.py
+++ b/scraper/tests/test_zim_language.py
@@ -1,0 +1,74 @@
+import pytest
+
+from gutenberg2zim.csv_catalog import CatalogEntry
+from gutenberg2zim.zim import get_zim_language_metadata, resolve_language
+
+
+def _make_books(languages_per_book: list[list[str]]) -> list[CatalogEntry]:
+    return [
+        CatalogEntry(book_id=i, languages=langs, lcc_shelf="")
+        for i, langs in enumerate(languages_per_book)
+    ]
+
+
+# resolve_language
+def test_resolve_language_two_letter_code():
+    assert resolve_language("en") == ["eng"]
+
+
+def test_resolve_language_three_letter_code():
+    assert resolve_language("gla") == ["gla"]
+
+
+def test_resolve_language_zim_map_override():
+    assert resolve_language("nah") == ["nhe"]
+
+
+def test_resolve_language_explicitly_empty():
+    assert resolve_language("myn") == []
+
+
+def test_resolve_language_unknown_code():
+    assert resolve_language("zzz") == []
+
+
+# get_zim_language_metadata
+def test_two_letter_codes_resolve():
+    books = _make_books([["en"], ["en"], ["fr"]])
+    result = get_zim_language_metadata(["en", "fr"], books)
+    assert "eng" in result
+    assert "fra" in result
+
+
+def test_sorted_by_book_count_descending():
+    books = _make_books([["fr"], ["fr"], ["fr"], ["en"]])
+    result = get_zim_language_metadata(["en", "fr"], books)
+    assert result == ["fra", "eng"]
+
+
+def test_unresolved_code_raises():
+    books = _make_books([["myn"]])
+    with pytest.raises(ValueError, match="myn"):
+        get_zim_language_metadata(["myn"], books)
+
+
+def test_empty_languages_returns_empty():
+    books = _make_books([["en"]])
+    result = get_zim_language_metadata([], books)
+    assert result == []
+
+
+# Regression tests for #337
+def test_gla_resolves():
+    books = _make_books([["gla"]])
+    assert get_zim_language_metadata(["gla"], books) == ["gla"]
+
+
+def test_nap_resolves():
+    books = _make_books([["nap"]])
+    assert get_zim_language_metadata(["nap"], books) == ["nap"]
+
+
+def test_oji_resolves():
+    books = _make_books([["oji"]])
+    assert get_zim_language_metadata(["oji"], books) == ["oji"]


### PR DESCRIPTION
Addresses feedback from #453. Closes #337.

**Problem**
`get_zim_language_metadata()` misses ISO 639-3 codes like `gla`, `nap`, and `oji` because it only looks up 2-letter keys in ISO_MATRIX. They resolve to None, producing an empty language list, and the ZIM crashes.

**Solution**

- Added `ISO_MATRIX_REV` fallback so codes already known as values like `gd -> gla` and `oj -> oji` can resolve correctly.
- Added `nap` to `ZIM_LANGUAGES_MAP` as discussed in the issue thread.
- Used `resolve_language()` helper to simplify
- Made unresolved-language a single line by routing it through `resolve_language().`
- Restored the single-line `language_counts` dict comprehension
- Changed scraper behavior to fail immediately with a clear `ValueError` pointing to `--zim-languages` whenever a code cannot be resolved
- Added tests in `test_zim_language.py.`
- Added a `CHANGELOG` entry

Passes `hatch run test:run` with the added tests