### PR TITLE
rename length constraints to graphemes

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -34,24 +34,24 @@
       "required": false,
       "title": "Title",
       "description": "Custom title for your project and ZIM.",
-      "minLength": 1,
-      "maxLength": 30
+      "minGraphemes": 1,
+      "maxGraphemes": 30
     },
     "zim_desc": {
       "type": "string",
       "required": false,
       "title": "Description",
       "description": "Description for ZIM",
-      "minLength": 1,
-      "maxLength": 80
+      "minGraphemes": 1,
+      "maxGraphemes": 80
     },
     "zim_long_desc": {
       "type": "string",
       "required": false,
       "title": "Long Description",
       "description": "Long Description for ZIM",
-      "minLength": 1,
-      "maxLength": 4000
+      "minGraphemes": 1,
+      "maxGraphemes": 4000
     },
     "zim_languages": {
       "type": "string",


### PR DESCRIPTION
## Changes
- rename length constraints to end with graphemes (See openzim/zimfarm#1890)