### PR TITLE
Fix: light/dark variants for format buttons, drop inactive and unavailable items

### DIFF
--- a/ui/src/components/book/BookDetailInfo.vue
+++ b/ui/src/components/book/BookDetailInfo.vue
@@ -2,7 +2,12 @@
 import type { Book } from '@/types'
 import { computed } from 'vue'
 import { useFormatters } from '@/composables/useFormatters'
-import { normalizeImagePath, getPopularityStars, formatDownloads } from '@/utils/format-utils'
+import {
+  normalizeImagePath,
+  getPopularityStars,
+  formatDownloads,
+  formatLabel
+} from '@/utils/format-utils'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -18,7 +23,7 @@ function orderedFormats(order: string[]) {
     .filter((f): f is NonNullable<typeof f> => !!f)
 }
 
-const viewFormats = computed(() => orderedFormats(['html', 'pdf', 'epub']))
+const viewFormats = computed(() => orderedFormats(['html']))
 const downloadFormats = computed(() => orderedFormats(['pdf', 'epub']))
 </script>
 
@@ -76,7 +81,7 @@ const downloadFormats = computed(() => orderedFormats(['pdf', 'epub']))
           <div class="inter-13 text-medium-emphasis mb-1">{{ t('book.lccShelf') }}</div>
           <router-link
             :to="`/lcc-shelf/${book.lccShelf}`"
-            class="inter-13 text-decoration-underline text-primary"
+            class="inter-13 text-decoration-underline shelf-link"
           >
             {{ book.lccShelf }}
           </router-link>
@@ -89,15 +94,16 @@ const downloadFormats = computed(() => orderedFormats(['pdf', 'epub']))
             <span class="action-label">{{ t('book.view') }}</span>
             <v-btn
               v-for="fmt in viewFormats"
+              v-show="fmt.available"
               :key="`view-${fmt.format}`"
               :href="fmt.path"
-              :disabled="!fmt.available"
               variant="outlined"
+              :elevation="0"
               size="small"
               rounded="md"
               class="text-none format-btn"
             >
-              {{ fmt.format.toUpperCase() }}
+              {{ formatLabel(fmt.format) }}
             </v-btn>
           </div>
 
@@ -105,15 +111,16 @@ const downloadFormats = computed(() => orderedFormats(['pdf', 'epub']))
             <span class="action-label">{{ t('book.download') }}</span>
             <v-btn
               v-for="fmt in downloadFormats"
+              v-show="fmt.available"
               :key="`dl-${fmt.format}`"
               :href="fmt.path"
-              :disabled="!fmt.available"
               variant="outlined"
+              :elevation="0"
               size="small"
               rounded="md"
               class="text-none format-btn"
             >
-              {{ fmt.format.toUpperCase() }}
+              {{ formatLabel(fmt.format) }}
             </v-btn>
           </div>
         </div>
@@ -265,7 +272,7 @@ const downloadFormats = computed(() => orderedFormats(['pdf', 'epub']))
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.75rem 1.5rem;
+  gap: 0.75rem 2.5rem;
 }
 
 .format-group {
@@ -282,6 +289,15 @@ const downloadFormats = computed(() => orderedFormats(['pdf', 'epub']))
 .author-name:hover,
 .author-name:focus {
   color: rgb(var(--v-theme-authorFocus));
+}
+
+.shelf-link {
+  color: rgb(var(--v-theme-author));
+}
+
+.shelf-link:hover,
+.shelf-link:focus {
+  color: rgb(var(--v-theme-text));
 }
 
 .meta-row {

--- a/ui/src/components/book/ShelfBookCard.vue
+++ b/ui/src/components/book/ShelfBookCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { BookPreview } from '@/types'
-import { getPopularityStars } from '@/utils/format-utils'
+import { getPopularityStars, formatLabel } from '@/utils/format-utils'
 import BookCoverImage from '@/components/common/BookCoverImage.vue'
 
 defineProps<{
@@ -19,7 +19,7 @@ defineProps<{
     />
 
     <div v-if="book.availableFormats?.length" class="format-links text-caption mb-2">
-      {{ book.availableFormats.map((f) => f.toUpperCase()).join(' · ') }}
+      {{ book.availableFormats.map(formatLabel).join(' · ') }}
     </div>
 
     <h3 class="shelf-book-title text-body-2 font-weight-bold mb-1">
@@ -46,8 +46,20 @@ defineProps<{
   width: 180px;
   min-width: 180px;
   color: inherit;
-  border-right: 2px solid rgb(var(--v-theme-grid));
+  border: 2px solid rgb(var(--v-theme-grid));
   padding: 1rem 1.25rem;
+  margin-left: -2px;
+  transition: border-color 0.2s ease;
+}
+
+.shelf-book-card:first-child {
+  margin-left: 0;
+}
+
+.shelf-book-card:hover,
+.shelf-book-card:focus {
+  border-color: rgb(var(--v-theme-text));
+  z-index: 1;
 }
 
 .shelf-book-cover {

--- a/ui/src/components/book/ShelfCarousel.vue
+++ b/ui/src/components/book/ShelfCarousel.vue
@@ -32,8 +32,6 @@ const { t } = useI18n()
 .shelf-books-row {
   display: flex;
   overflow-x: auto;
-  border: 2px solid rgb(var(--v-theme-grid));
-  border-right: none;
   width: fit-content;
   max-width: 100%;
 }

--- a/ui/src/constants/theme.ts
+++ b/ui/src/constants/theme.ts
@@ -13,7 +13,7 @@ export const THEME_COLORS = {
   FORMAT: '#ef502b',
   STAR: '#ffce00',
   TITLE: '#c48e4e',
-  AUTHOR: '#fcefe3',
+  AUTHOR: '#c48e4e',
   AUTHOR_FOCUS: '#69afc6',
   DESCRIPTION: '#666666',
   FOCUS_BOOK: '#3c485a',
@@ -21,9 +21,13 @@ export const THEME_COLORS = {
   BGD_1: '#e8f6ff',
   BGD_2: '#fcefe3',
   BGD_3_FILL: '#f9f9f9',
+  BGD_3_FILL_DARK: '#2a2a2a',
   BGD_3_OUTLINE: '#e2e2e2',
+  BGD_3_OUTLINE_DARK: '#555555',
   TEXT: '#000000',
+  TEXT_DARK: '#ffffff',
   GRID: '#cccccc',
+  GRID_DARK: '#444444',
   ON_PRIMARY: '#FFFFFF'
 } as const
 

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -41,12 +41,28 @@ async function loadVuetify() {
     grid: THEME_COLORS.GRID
   }
 
+  const lightColors = {
+    ...sharedColors,
+    grid: THEME_COLORS.GRID,
+    text: THEME_COLORS.TEXT,
+    bgd3Fill: THEME_COLORS.BGD_3_FILL,
+    bgd3Outline: THEME_COLORS.BGD_3_OUTLINE
+  }
+
+  const darkColors = {
+    ...sharedColors,
+    grid: THEME_COLORS.GRID_DARK,
+    text: THEME_COLORS.TEXT_DARK,
+    bgd3Fill: THEME_COLORS.BGD_3_FILL_DARK,
+    bgd3Outline: THEME_COLORS.BGD_3_OUTLINE_DARK
+  }
+
   const lightTheme: ThemeDefinition = {
     dark: false,
     colors: {
       background: THEME_COLORS.BACKGROUND_LIGHT,
       surface: THEME_COLORS.SURFACE_LIGHT,
-      ...sharedColors
+      ...lightColors
     }
   }
 
@@ -55,7 +71,7 @@ async function loadVuetify() {
     colors: {
       background: THEME_COLORS.BACKGROUND_DARK,
       surface: THEME_COLORS.SURFACE_DARK,
-      ...sharedColors
+      ...darkColors
     }
   }
 

--- a/ui/src/utils/format-utils.ts
+++ b/ui/src/utils/format-utils.ts
@@ -20,6 +20,10 @@ export function formatAuthorLifespan(birthYear: string | null, deathYear: string
   return ''
 }
 
+export function formatLabel(format: string): string {
+  return format === 'epub' ? 'ePUB' : format.toUpperCase()
+}
+
 export function formatDownloads(downloads: number): string {
   if (downloads >= 1000000) {
     return `${(downloads / 1000000).toFixed(1)}M`

--- a/ui/src/views/BookDetailView.integration.spec.ts
+++ b/ui/src/views/BookDetailView.integration.spec.ts
@@ -124,7 +124,7 @@ describe('BookDetailView Integration', () => {
     it('displays available download formats', async () => {
       const wrapper = await mountView()
 
-      expect(wrapper.text()).toContain('EPUB')
+      expect(wrapper.text()).toContain('ePUB')
       expect(wrapper.text()).toContain('PDF')
     })
   })


### PR DESCRIPTION
- Added more themes for light and dark mode
- Dropped unavailable format buttons 
- Removed ePUB and PDF from View format