### PR TITLE
docs: use correct translatewiki.net project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ as of 2.0.0.
 - Finalize implementation of scraper progress (#289)
 - Move to another default mirror + add CLI flag to select mirror to use (#301)
 - Split build logic in Dockerfile to separate dependencies layer from scraper code layer (#302)
-- Prepare structure for TranslateWiki (#312)
+- Prepare structure for translatewiki.net (#312)
 - Remove « .html » extension (#166)
 - Configure libzim verbosity based on `--debug` flag (#326)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The project consists of several components:
 
 ### 1. Adding UI Translations
 
-UI translations are managed through [TranslateWiki](https://translatewiki.net/w/i.php?title=Special:MessageGroupStats/kiwix-gutenberg). We welcome volunteers to contribute translations in their native languages.
+UI translations are managed through [translatewiki.net](https://translatewiki.net/w/i.php?title=Special:MessageGroupStats/kiwix-gutenberg). We welcome volunteers to contribute translations in their native languages.
 
 When a new language `<new_code>` starts being translated, developers need to add support for it:
 

--- a/scraper/src/gutenberg2zim/scripts/validate_i18n.py
+++ b/scraper/src/gutenberg2zim/scripts/validate_i18n.py
@@ -304,7 +304,7 @@ def main() -> int:
                 f"❌ {len(missing_in_qqq)} keys missing documentation in qqq.json"
             )
             errors.append(
-                "   TranslateWiki requires documentation for all keys in qqq.json"
+                "   translatewiki.net requires documentation for all keys in qqq.json"
             )
             for key in sorted(missing_in_qqq):
                 errors.append(f"   - {key}")


### PR DESCRIPTION
The project is called translatewiki.net, not TranslateWiki.