### PR TITLE
feat: add a books page with grid-cell like structure and a list view

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -5,7 +5,8 @@
 		"home": "Home",
 		"authors": "Authors",
 		"shelves": "Shelves",
-		"about": "About"
+		"about": "About",
+		"books": "Books"
 	},
 	"home": {
 		"title": "Project Gutenberg Library",
@@ -117,6 +118,8 @@
 		"selected": "selected",
 		"gridView": "Grid view",
 		"listView": "List view",
+		"previous": "Previous",
+		"next": "Next",
 		"browseAll": "Browse All",
 		"browseAllShelves": "Browse All Shelves",
 		"browseAllAuthors": "Browse All Authors",

--- a/locales/qqq.json
+++ b/locales/qqq.json
@@ -10,7 +10,8 @@
 		"home": "Title attribute for the homepage link/button",
 		"authors": "Title attribute for the authors page link/button",
 		"shelves": "Title attribute for the shelves page link/button",
-		"about": "Title attribute for the about page link/button"
+		"about": "Title attribute for the about page link/button",
+		"books": "Title attribute for the books page link/button"
 	},
 	"home": {
 		"title": "Main title for the Project Gutenberg library site",
@@ -122,6 +123,8 @@
 		"selected": "Text indicating items are selected",
 		"gridView": "Label for grid view layout option",
 		"listView": "Label for list view layout option",
+		"previous": "Label for the previous page button in pagination controls",
+		"next": "Label for the next page button in pagination controls",
 		"browseAll": "Label for browsing all items",
 		"browseAllShelves": "Label for browsing all shelves",
 		"browseAllAuthors": "Label for browsing all authors",

--- a/scraper/src/gutenberg2zim/export.py
+++ b/scraper/src/gutenberg2zim/export.py
@@ -1,12 +1,13 @@
 import io
 import urllib.parse
+import warnings
 import zipfile
 from collections.abc import Iterable
 from dataclasses import asdict
 from pathlib import Path
 
 import bs4
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup, Tag, XMLParsedAsHTMLWarning
 from jinja2 import Environment, PackageLoader
 from PIL.Image import open as pilopen
 from zimscraperlib.image.optimization import (
@@ -48,6 +49,8 @@ from gutenberg2zim.utils import (
     read_file,
     save_file,
 )
+
+warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
 
 jinja_env = Environment(  # noqa: S701
     loader=PackageLoader("gutenberg2zim", "templates")
@@ -762,6 +765,7 @@ def _book_to_preview(book: Book, formats: list[str]) -> BookPreview:
         cover_path=cover_path,
         lcc_shelf=book.lcc_shelf,
         available_formats=book.requested_formats(formats),
+        description=book.description,
     )
 
 

--- a/scraper/src/gutenberg2zim/schemas.py
+++ b/scraper/src/gutenberg2zim/schemas.py
@@ -63,6 +63,7 @@ class BookPreview(CamelModel):
     cover_path: str | None = None
     lcc_shelf: str | None = None
     available_formats: list[str] = []
+    description: str | None = None
 
 
 class Book(BookPreview):

--- a/scraper/src/gutenberg2zim/scripts/validate_i18n.py
+++ b/scraper/src/gutenberg2zim/scripts/validate_i18n.py
@@ -122,7 +122,7 @@ def extract_keys_from_file(file_path: Path, file_type: str) -> set[str]:
     content = file_path.read_text(encoding="utf-8")
 
     patterns = {
-        "vue": r't\s*\(\s*["\']([^"\']+)["\']',
+        "vue": r'\bt\s*\(\s*["\']([^"\']+)["\']',
         "python": r'i18n\.t\s*\(\s*["\']([^"\']+)["\']',
         "html": r'data-l10n-id\s*=\s*["\']([^"\']+)["\']',
     }

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js'
 import pluginVue from 'eslint-plugin-vue'
 import tseslint from 'typescript-eslint'
+import globals from 'globals'
 import prettierSkipFormatting from '@vue/eslint-config-prettier/skip-formatting'
 
 export default [
@@ -24,6 +25,7 @@ export default [
         parser: tseslint.parser,
       },
       globals: {
+        ...globals.browser,
         console: 'readonly',
       },
     },

--- a/ui/src/components/book/BookCard.vue
+++ b/ui/src/components/book/BookCard.vue
@@ -66,6 +66,7 @@ defineProps<{
   min-height: 3rem;
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/ui/src/components/book/BooksGrid.vue
+++ b/ui/src/components/book/BooksGrid.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import type { BookPreview } from '@/types'
+import ShelfBookCard from './ShelfBookCard.vue'
+
+defineProps<{
+  books: BookPreview[]
+}>()
+</script>
+
+<template>
+  <div class="books-grid">
+    <div v-for="book in books" :key="book.id" class="grid-cell">
+      <shelf-book-card :book="book" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.books-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 180px);
+  justify-content: center;
+  padding: 1px;
+}
+
+.grid-cell {
+  width: calc(100% + 2px);
+  height: calc(100% + 2px);
+  margin: -1px;
+}
+</style>

--- a/ui/src/components/book/BooksList.vue
+++ b/ui/src/components/book/BooksList.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { BookPreview } from '@/types'
+import ListBookCard from './ListBookCard.vue'
+import { useInfiniteScroll } from '@/composables/useInfiniteScroll'
+
+const props = defineProps<{
+  books: BookPreview[]
+}>()
+
+const emit = defineEmits<{
+  'update:displayedCount': [number]
+}>()
+
+const { t } = useI18n()
+
+const { displayedItems, hasMore, loadMore } = useInfiniteScroll(() => props.books, 24)
+
+watch(
+  () => displayedItems.value.length,
+  (count) => {
+    emit('update:displayedCount', count)
+  },
+  { immediate: true }
+)
+
+const sentinel = ref<HTMLElement | null>(null)
+let observer: IntersectionObserver | null = null
+
+function setupObserver() {
+  observer?.disconnect()
+
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries[0]?.isIntersecting && hasMore.value) {
+        loadMore()
+      }
+    },
+    { rootMargin: '100px' }
+  )
+
+  if (sentinel.value) {
+    observer.observe(sentinel.value)
+  }
+}
+
+onMounted(setupObserver)
+
+onUnmounted(() => {
+  observer?.disconnect()
+})
+</script>
+
+<template>
+  <div class="books-list">
+    <div v-for="book in displayedItems" :key="book.id" class="list-cell">
+      <list-book-card :book="book" />
+    </div>
+    <div ref="sentinel" class="sentinel text-caption text-center py-4">
+      <span v-if="hasMore">{{ t('common.loading') }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.books-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.list-cell {
+  margin-bottom: -2px;
+}
+
+.list-cell:nth-last-child(2) {
+  margin-bottom: 0;
+}
+
+.sentinel {
+  min-height: 40px;
+}
+</style>

--- a/ui/src/components/book/ListBookCard.vue
+++ b/ui/src/components/book/ListBookCard.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import type { BookPreview } from '@/types'
+import { getPopularityStars, formatLabel } from '@/utils/format-utils'
+import BookCoverImage from '@/components/common/BookCoverImage.vue'
+
+defineProps<{
+  book: BookPreview
+}>()
+</script>
+
+<template>
+  <router-link :to="`/book/${book.id}`" class="list-book-card text-decoration-none">
+    <div class="cover-wrapper">
+      <book-cover-image
+        :cover-path="book.coverPath"
+        :alt="`${book.title} cover`"
+        :size="64"
+        height="140px"
+      />
+    </div>
+
+    <div class="list-book-content">
+      <div v-if="book.availableFormats?.length" class="format-links text-caption mb-1">
+        {{ book.availableFormats.map(formatLabel).join(' · ') }}
+      </div>
+
+      <h3 class="list-book-title text-body-2 font-weight-bold mb-1">
+        {{ book.title }}
+      </h3>
+
+      <p class="list-book-author text-caption text-medium-emphasis mb-2">
+        {{ book.author?.name }}
+      </p>
+
+      <p
+        v-if="book.description"
+        class="list-book-description text-caption text-medium-emphasis mb-2"
+      >
+        {{ book.description }}
+      </p>
+
+      <span
+        class="text-star text-body-2"
+        :aria-label="`Popularity: ${book.popularity} out of 5 stars`"
+      >
+        {{ getPopularityStars(book.popularity) }}
+      </span>
+    </div>
+  </router-link>
+</template>
+
+<style scoped>
+.list-book-card {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+  color: inherit;
+  border: 2px solid rgb(var(--v-theme-grid));
+  padding: 1rem 1.25rem;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.list-book-card:hover,
+.list-book-card:focus {
+  border-color: rgb(var(--v-theme-text));
+  box-shadow: 0 0 5px 0 rgb(var(--v-theme-text));
+  z-index: 1;
+}
+
+.cover-wrapper {
+  flex: 0 0 100px;
+}
+
+.list-book-content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.format-links {
+  color: rgb(var(--v-theme-format));
+  font-family: 'Inter Variable', 'Inter', sans-serif;
+  font-weight: 500;
+}
+
+.list-book-title {
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+.list-book-author {
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.list-book-description {
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+  line-height: 1.5;
+}
+</style>

--- a/ui/src/components/book/ShelfBookCard.vue
+++ b/ui/src/components/book/ShelfBookCard.vue
@@ -43,22 +43,22 @@ defineProps<{
 .shelf-book-card {
   display: flex;
   flex-direction: column;
-  width: 180px;
-  min-width: 180px;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
   color: inherit;
   border: 2px solid rgb(var(--v-theme-grid));
   padding: 1rem 1.25rem;
-  margin-left: -2px;
-  transition: border-color 0.2s ease;
-}
-
-.shelf-book-card:first-child {
-  margin-left: 0;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .shelf-book-card:hover,
 .shelf-book-card:focus {
   border-color: rgb(var(--v-theme-text));
+  box-shadow: 0 0 5px 0 rgb(var(--v-theme-text));
   z-index: 1;
 }
 
@@ -84,5 +84,8 @@ defineProps<{
 
 .shelf-book-author {
   margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>

--- a/ui/src/components/book/ShelfCarousel.vue
+++ b/ui/src/components/book/ShelfCarousel.vue
@@ -17,7 +17,9 @@ const { t } = useI18n()
     </h2>
 
     <div class="shelf-books-row">
-      <shelf-book-card v-for="book in books" :key="book.id" :book="book" />
+      <div v-for="book in books" :key="book.id" class="carousel-card-wrapper">
+        <shelf-book-card :book="book" />
+      </div>
     </div>
   </div>
 </template>
@@ -34,9 +36,20 @@ const { t } = useI18n()
   overflow-x: auto;
   width: fit-content;
   max-width: 100%;
+  padding: 5px;
 }
 
 .shelf-books-row::-webkit-scrollbar {
   display: none;
+}
+
+.carousel-card-wrapper {
+  width: 180px;
+  min-width: 180px;
+  margin-left: -2px;
+}
+
+.carousel-card-wrapper:first-child {
+  margin-left: 0;
 }
 </style>

--- a/ui/src/components/common/BasePaginationButton.vue
+++ b/ui/src/components/common/BasePaginationButton.vue
@@ -1,0 +1,121 @@
+<script lang="ts">
+import { computed } from 'vue'
+
+export function usePaginationPages(
+  currentPage: () => number,
+  totalPages: () => number,
+  maxVisible: number = 7
+) {
+  const visibleItems = computed<(number | string)[]>(() => {
+    const current = currentPage()
+    const total = totalPages()
+
+    if (total <= maxVisible) {
+      return Array.from({ length: total }, (_, i) => i + 1)
+    }
+
+    const pages: (number | string)[] = []
+    const side = Math.floor((maxVisible - 5) / 2)
+
+    let start = current - side
+    let end = current + side
+
+    if (current <= side + 2) {
+      start = 2
+      end = maxVisible - 2
+    }
+
+    if (current >= total - side - 1) {
+      start = total - maxVisible + 3
+      end = total - 1
+    }
+
+    pages.push(1)
+
+    if (start > 2) {
+      pages.push('...')
+    }
+
+    for (let i = start; i <= end; i++) {
+      pages.push(i)
+    }
+
+    if (end < total - 1) {
+      pages.push('...')
+    }
+
+    if (total > 1) {
+      pages.push(total)
+    }
+
+    return pages
+  })
+
+  const canGoPrevious = computed(() => currentPage() > 1)
+  const canGoNext = computed(() => currentPage() < totalPages())
+
+  return {
+    visibleItems,
+    canGoPrevious,
+    canGoNext
+  }
+}
+</script>
+
+<script setup lang="ts">
+defineProps<{
+  active?: boolean
+  disabled?: boolean
+}>()
+
+defineEmits<{
+  click: []
+}>()
+</script>
+
+<template>
+  <v-btn
+    :disabled="disabled"
+    elevation="0"
+    variant="text"
+    :class="['pagination-btn', { 'pagination-btn--active': active }]"
+    @click="$emit('click')"
+  >
+    <slot />
+  </v-btn>
+</template>
+
+<style scoped>
+.pagination-btn {
+  border: 1px solid rgb(var(--v-theme-grid));
+  border-radius: 0;
+  background-color: transparent;
+  color: rgb(var(--v-theme-text));
+  box-shadow: none;
+  min-width: 40px;
+  height: 40px;
+  padding: 0 12px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-transform: none;
+}
+
+.pagination-btn--active {
+  background-color: rgb(var(--v-theme-text));
+  color: rgb(var(--v-theme-background));
+  border-color: rgb(var(--v-theme-text));
+}
+
+.pagination-btn:not(.pagination-btn--active):not(:disabled):hover {
+  background-color: rgb(var(--v-theme-focusBook));
+  color: rgb(var(--v-theme-background));
+  border-color: rgb(var(--v-theme-focusBook));
+}
+
+.pagination-btn:disabled,
+.pagination-btn.v-btn--disabled {
+  background-color: transparent;
+  color: rgb(var(--v-theme-text));
+  opacity: 0.4;
+}
+</style>

--- a/ui/src/components/common/PaginationControl.spec.ts
+++ b/ui/src/components/common/PaginationControl.spec.ts
@@ -8,7 +8,21 @@ import { mount } from '@vue/test-utils'
 import PaginationControl from './PaginationControl.vue'
 
 const createWrapper = (props: { currentPage: number; totalPages: number }) =>
-  mount(PaginationControl, { props })
+  mount(PaginationControl, {
+    props,
+    global: {
+      mocks: {
+        $t: (key: string) => key.split('.').pop()
+      },
+      stubs: {
+        BasePaginationButton: {
+          props: ['active', 'disabled'],
+          template:
+            '<button :disabled="disabled" :class="{ active }" @click="$emit(\'click\')"><slot /></button>'
+        }
+      }
+    }
+  })
 
 describe('PaginationControl', () => {
   it.each([
@@ -21,32 +35,88 @@ describe('PaginationControl', () => {
     ({ currentPage, totalPages, shouldRender }) => {
       const wrapper = createWrapper({ currentPage, totalPages })
 
-      expect(wrapper.findComponent({ name: 'VPagination' }).exists()).toBe(shouldRender)
+      expect(wrapper.find('.pagination-control').exists()).toBe(shouldRender)
     }
   )
 
-  it('passes correct props to v-pagination', () => {
+  it('highlights the active page button', () => {
     const wrapper = createWrapper({
       currentPage: 3,
       totalPages: 10
     })
 
-    const pagination = wrapper.findComponent({ name: 'VPagination' })
-    expect(pagination.props('modelValue')).toBe(3)
-    expect(pagination.props('length')).toBe(10)
+    const buttons = wrapper.findAll('button')
+    const activeButton = buttons.find((btn) => btn.classes('active'))
+
+    expect(activeButton).toBeDefined()
+    expect(activeButton!.text()).toBe('3')
   })
 
-  it('emits go-to-page when page changes', async () => {
+  it('emits go-to-page when a page button is clicked', async () => {
     const wrapper = createWrapper({
       currentPage: 1,
       totalPages: 5
     })
 
-    const pagination = wrapper.findComponent({ name: 'VPagination' })
-    await pagination.vm.$emit('update:modelValue', 3)
+    const buttons = wrapper.findAll('button')
+    const page3Button = buttons.find((btn) => btn.text() === '3')
 
-    const emittedEvents = wrapper.emitted('go-to-page')
-    expect(emittedEvents).toBeDefined()
-    expect(emittedEvents![0]).toEqual([3])
+    expect(page3Button).toBeDefined()
+    await page3Button!.trigger('click')
+
+    expect(wrapper.emitted('go-to-page')).toBeDefined()
+    expect(wrapper.emitted('go-to-page')![0]).toEqual([3])
+  })
+
+  it('emits go-to-page with previous page when Previous is clicked', async () => {
+    const wrapper = createWrapper({
+      currentPage: 3,
+      totalPages: 5
+    })
+
+    const buttons = wrapper.findAll('button')
+    const prevButton = buttons[0]!
+
+    expect(prevButton.text()).toContain('previous')
+    await prevButton.trigger('click')
+
+    expect(wrapper.emitted('go-to-page')).toBeDefined()
+    expect(wrapper.emitted('go-to-page')![0]).toEqual([2])
+  })
+
+  it('emits go-to-page with next page when Next is clicked', async () => {
+    const wrapper = createWrapper({
+      currentPage: 3,
+      totalPages: 5
+    })
+
+    const buttons = wrapper.findAll('button')
+    const nextButton = buttons[buttons.length - 1]!
+
+    expect(nextButton.text()).toContain('next')
+    await nextButton.trigger('click')
+
+    expect(wrapper.emitted('go-to-page')).toBeDefined()
+    expect(wrapper.emitted('go-to-page')![0]).toEqual([4])
+  })
+
+  it('disables Previous button on first page', () => {
+    const wrapper = createWrapper({
+      currentPage: 1,
+      totalPages: 5
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons[0]!.attributes('disabled')).toBeDefined()
+  })
+
+  it('disables Next button on last page', () => {
+    const wrapper = createWrapper({
+      currentPage: 5,
+      totalPages: 5
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons[buttons.length - 1]!.attributes('disabled')).toBeDefined()
   })
 })

--- a/ui/src/components/common/PaginationControl.vue
+++ b/ui/src/components/common/PaginationControl.vue
@@ -1,21 +1,66 @@
 <script setup lang="ts">
-defineProps<{
+import { useI18n } from 'vue-i18n'
+import BasePaginationButton, { usePaginationPages } from './BasePaginationButton.vue'
+
+const props = defineProps<{
   currentPage: number
   totalPages: number
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   'go-to-page': [page: number]
 }>()
+
+const { t } = useI18n()
+
+const { visibleItems, canGoPrevious, canGoNext } = usePaginationPages(
+  () => props.currentPage,
+  () => props.totalPages,
+  7
+)
+
+function goToPage(page: number) {
+  if (page >= 1 && page <= props.totalPages) {
+    emit('go-to-page', page)
+  }
+}
 </script>
 
 <template>
-  <div v-if="totalPages > 1" class="mt-6">
-    <v-pagination
-      :model-value="currentPage"
-      :length="totalPages"
-      :total-visible="7"
-      @update:model-value="$emit('go-to-page', $event)"
-    />
+  <div v-if="totalPages > 1" class="pagination-control">
+    <base-pagination-button :disabled="!canGoPrevious" @click="goToPage(currentPage - 1)">
+      &lt; {{ t('common.previous') }}
+    </base-pagination-button>
+
+    <template v-for="(item, index) in visibleItems" :key="`${item}-${index}`">
+      <span v-if="item === '...'" class="ellipsis text-body-2 text-medium-emphasis"> ... </span>
+      <base-pagination-button v-else :active="item === currentPage" @click="goToPage(Number(item))">
+        {{ item }}
+      </base-pagination-button>
+    </template>
+
+    <base-pagination-button :disabled="!canGoNext" @click="goToPage(currentPage + 1)">
+      {{ t('common.next') }} &gt;
+    </base-pagination-button>
   </div>
 </template>
+
+<style scoped>
+.pagination-control {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 1.5rem;
+}
+
+.ellipsis {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  height: 40px;
+  user-select: none;
+}
+</style>

--- a/ui/src/components/layout/AppHeader.vue
+++ b/ui/src/components/layout/AppHeader.vue
@@ -8,6 +8,7 @@ const drawer = ref(false)
 
 const navItems = computed(() => [
   { title: t('nav.home'), to: '/', icon: 'mdi-home' },
+  { title: t('nav.books'), to: '/books', icon: 'mdi-book-multiple' },
   { title: t('nav.authors'), to: '/authors', icon: 'mdi-account-multiple' },
   { title: t('nav.shelves'), to: '/lcc-shelves', icon: 'mdi-bookshelf' },
   { title: t('nav.about'), to: '/about', icon: 'mdi-information' }

--- a/ui/src/composables/useInfiniteScroll.ts
+++ b/ui/src/composables/useInfiniteScroll.ts
@@ -1,0 +1,28 @@
+import { ref, computed, watch } from 'vue'
+
+export function useInfiniteScroll<T>(items: () => T[], batchSize: number = 24) {
+  const displayedCount = ref(batchSize)
+
+  const displayedItems = computed(() => items().slice(0, displayedCount.value))
+
+  const hasMore = computed(() => displayedItems.value.length < items().length)
+
+  function loadMore() {
+    if (!hasMore.value) return
+    displayedCount.value = Math.min(displayedCount.value + batchSize, items().length)
+  }
+
+  function reset() {
+    displayedCount.value = batchSize
+  }
+
+  watch(items, reset)
+
+  return {
+    displayedItems,
+    hasMore,
+    loadMore,
+    reset,
+    displayedCount
+  }
+}

--- a/ui/src/constants/theme.ts
+++ b/ui/src/constants/theme.ts
@@ -17,6 +17,7 @@ export const THEME_COLORS = {
   AUTHOR_FOCUS: '#69afc6',
   DESCRIPTION: '#666666',
   FOCUS_BOOK: '#3c485a',
+  FOCUS_BOOK_DARK: '#5c6b7d',
   MENU_ACTIVE: '#0c858b',
   BGD_1: '#e8f6ff',
   BGD_2: '#fcefe3',

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -54,7 +54,8 @@ async function loadVuetify() {
     grid: THEME_COLORS.GRID_DARK,
     text: THEME_COLORS.TEXT_DARK,
     bgd3Fill: THEME_COLORS.BGD_3_FILL_DARK,
-    bgd3Outline: THEME_COLORS.BGD_3_OUTLINE_DARK
+    bgd3Outline: THEME_COLORS.BGD_3_OUTLINE_DARK,
+    focusBook: THEME_COLORS.FOCUS_BOOK_DARK
   }
 
   const lightTheme: ThemeDefinition = {

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import BooksView from '../views/BooksView.vue'
 import BookDetailView from '../views/BookDetailView.vue'
 import AuthorListView from '../views/AuthorListView.vue'
 import AuthorDetailView from '../views/AuthorDetailView.vue'
@@ -16,6 +17,12 @@ const router = createRouter({
       name: 'home',
       component: HomeView,
       meta: { title: 'Home - Gutenberg Library' }
+    },
+    {
+      path: '/books',
+      name: 'books',
+      component: BooksView,
+      meta: { title: 'Books - Gutenberg Library' }
     },
     {
       path: '/book/:id',

--- a/ui/src/types/Book.ts
+++ b/ui/src/types/Book.ts
@@ -20,6 +20,7 @@ export interface BookPreview {
   coverPath: string | null
   lccShelf: string | null
   availableFormats?: string[]
+  description?: string | null
 }
 
 export interface Book extends Omit<BookPreview, 'author'> {

--- a/ui/src/views/BooksView.vue
+++ b/ui/src/views/BooksView.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useMainStore } from '@/stores/main'
+import type { BookPreview, SortOption, SortOrder, Books } from '@/types'
+import BooksGrid from '@/components/book/BooksGrid.vue'
+import BooksList from '@/components/book/BooksList.vue'
+import CollapsibleFilters from '@/components/common/CollapsibleFilters.vue'
+import EmptyState from '@/components/common/EmptyState.vue'
+import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+import PaginationControl from '@/components/common/PaginationControl.vue'
+import ItemCount from '@/components/common/ItemCount.vue'
+import { usePagination } from '@/composables/usePagination'
+import { useListLoader } from '@/composables/useListLoader'
+import { useSorting, type SortConfig } from '@/composables/useSorting'
+import { extractUniqueValues } from '@/utils/format-utils'
+import { LAYOUT } from '@/constants/theme'
+import { MESSAGES } from '@/constants/messages'
+
+const { t } = useI18n()
+const main = useMainStore()
+
+const PAGE_SIZE = 24
+
+const selectedLanguages = ref<string[]>([])
+const sortBy = ref<SortOption>('popularity')
+const sortOrder = ref<SortOrder>('desc')
+const viewMode = ref<'grid' | 'list'>('grid')
+const listDisplayedCount = ref(PAGE_SIZE)
+
+const isGridView = computed(() => viewMode.value === 'grid')
+
+const {
+  items: books,
+  loading: booksLoading,
+  loadItems: loadBooks
+} = useListLoader<BookPreview, Books>(() => main.fetchBooks(), 'books')
+
+const availableLanguages = computed(() =>
+  extractUniqueValues(books.value, (book) => book.languages)
+)
+
+const filteredBooks = computed(() => {
+  if (selectedLanguages.value.length === 0) {
+    return books.value
+  }
+  return books.value.filter((book) =>
+    book.languages.some((lang) => selectedLanguages.value.includes(lang))
+  )
+})
+
+const sortOptions: SortConfig<BookPreview>[] = [
+  {
+    value: 'popularity',
+    compare: (a, b) => a.popularity - b.popularity
+  },
+  {
+    value: 'title',
+    compare: (a, b) => a.title.localeCompare(b.title)
+  }
+]
+
+const { sortedItems: sortedBooks } = useSorting(
+  () => filteredBooks.value,
+  sortBy,
+  sortOrder,
+  sortOptions
+)
+
+const {
+  currentPage,
+  paginatedItems: paginatedBooks,
+  totalPages,
+  goToPage,
+  resetPage
+} = usePagination(() => sortedBooks.value, PAGE_SIZE)
+
+watch([selectedLanguages, sortBy, sortOrder], () => {
+  resetPage()
+})
+
+onMounted(() => {
+  loadBooks()
+})
+</script>
+
+<template>
+  <div class="books-view">
+    <v-container>
+      <v-row v-if="booksLoading">
+        <v-col cols="12">
+          <loading-spinner :message="t('common.loading')" />
+        </v-col>
+      </v-row>
+
+      <v-row v-else-if="books.length > 0">
+        <v-col cols="12">
+          <div class="d-flex justify-space-between align-center mb-4 flex-wrap gap-3">
+            <item-count
+              :current="isGridView ? paginatedBooks.length : listDisplayedCount"
+              :total="sortedBooks.length"
+              type="books"
+            />
+            <v-btn-toggle
+              v-model="viewMode"
+              density="comfortable"
+              variant="outlined"
+              divided
+              mandatory
+            >
+              <v-btn value="grid" icon="mdi-view-grid" :aria-label="t('common.gridView')" />
+              <v-btn value="list" icon="mdi-view-list" :aria-label="t('common.listView')" />
+            </v-btn-toggle>
+          </div>
+
+          <collapsible-filters
+            :languages="availableLanguages"
+            v-model:selected-languages="selectedLanguages"
+            v-model:sort-by="sortBy"
+            v-model:sort-order="sortOrder"
+            class="mb-4"
+          />
+
+          <books-grid v-if="isGridView" :books="paginatedBooks" />
+          <books-list
+            v-else
+            :books="sortedBooks"
+            @update:displayed-count="listDisplayedCount = $event"
+          />
+
+          <pagination-control
+            v-if="isGridView && sortedBooks.length > PAGE_SIZE"
+            :current-page="currentPage"
+            :total-pages="totalPages"
+            @go-to-page="goToPage"
+          />
+        </v-col>
+      </v-row>
+
+      <v-row v-else>
+        <v-col cols="12">
+          <empty-state :message="t(MESSAGES.NO_BOOKS)" type="info" />
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<style scoped>
+.books-view {
+  padding: v-bind('LAYOUT.VIEW_PADDING');
+}
+
+@media (max-width: 960px) {
+  .books-view {
+    padding: v-bind('LAYOUT.VIEW_PADDING_MOBILE');
+  }
+}
+</style>


### PR DESCRIPTION
### What's new:
- A new books page
- A new grid-cell like structure for books
- Grid/List view
- Infinite scroll for List view with smart scroll
### What's Fixed:
The old regex of i18n validation matched the trailing `t` in identifiers like `$emit('click')`, falsely extracting click as an i18n key. Now it only matches `t('...')` / `$t('...')` calls.