### PR TITLE
Ref: Introduce the source-agnostic domain model

### DIFF
--- a/scraper/src/gutenberg2zim/adapters.py
+++ b/scraper/src/gutenberg2zim/adapters.py
@@ -1,0 +1,122 @@
+"""Conversions between the legacy Gutenberg models and the core domain model.
+
+These adapters allow gradual migration: existing code keeps producing
+`Book`/`Author` while new code consumes `Work`/`Creator`. They are
+deliberately lossless for the Gutenberg source, so `work_to_book(book_to_work(b))`
+round-trips.
+
+This module is transitional and will be removed once:
+- no module imports `gutenberg2zim.models` anymore (i.e. `Book`, `Author`
+  and the `repository` singleton are fully replaced by `Work`/`Creator` and
+  `core.work_store.WorkStore`), and
+- `gutenberg2zim/models.py` itself is deleted.
+
+It lives next to the legacy models (not in `core/`) because it is
+Gutenberg-specific; `core/` must stay source-agnostic.
+"""
+
+from gutenberg2zim.core.models import CollectionRef, Cover, Creator, Work
+from gutenberg2zim.models import Author, Book
+
+GUTENBERG_SOURCE = "gutenberg"
+LCC_SHELF_KIND = "lcc_shelf"
+
+
+def _parse_year(value: str | None) -> int | None:
+    """Parse a year from legacy string fields, None if missing or not numeric"""
+    if value and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def author_to_creator(author: Author) -> Creator:
+    return Creator(
+        id=author.gut_id,
+        name=author.name(),
+        sort_name=author.last_name or None,
+        birth_date=_parse_year(author.birth_year),
+        death_date=_parse_year(author.death_year),
+        extra={
+            "first_names": author.first_names,
+            "birth_year_raw": author.birth_year,
+            "death_year_raw": author.death_year,
+        },
+    )
+
+
+def creator_to_author(creator: Creator) -> Author:
+    # Recover the original split fields if this Creator came from author_to_creator
+    if "first_names" in creator.extra or "birth_year_raw" in creator.extra:
+        return Author(
+            gut_id=creator.id,
+            last_name=creator.sort_name or "",
+            first_names=creator.extra.get("first_names"),
+            birth_year=creator.extra.get("birth_year_raw"),
+            death_year=creator.extra.get("death_year_raw"),
+        )
+    # Best effort for Creators built by other means: last word as last name
+    parts = creator.name.rsplit(" ", 1)
+    return Author(
+        gut_id=creator.id,
+        last_name=parts[-1],
+        first_names=parts[0] if len(parts) > 1 else None,
+        birth_year=str(creator.birth_date) if creator.birth_date is not None else None,
+        death_year=str(creator.death_date) if creator.death_date is not None else None,
+    )
+
+
+def book_to_work(book: Book) -> Work:
+    collections = []
+    if book.lcc_shelf:
+        collections.append(
+            CollectionRef(id=book.lcc_shelf, name=book.lcc_shelf, kind=LCC_SHELF_KIND)
+        )
+    cover = None
+    if book.has_cover:
+        cover = Cover(
+            source_url=book._cover_href,
+            local_path=book.html_cover_path,
+        )
+    return Work(
+        id=str(book.book_id),
+        source=GUTENBERG_SOURCE,
+        title=book.title,
+        subtitle=book.subtitle,
+        creators=[author_to_creator(book.author)],
+        languages=list(book.languages),
+        license=book.license,
+        cover=cover,
+        collections=collections,
+        popularity=book.popularity,
+        description=book.description,
+        extra={
+            "downloads": book.downloads,
+            "unsupported_formats": list(book.unsupported_formats),
+            "has_cover": book.has_cover,
+        },
+    )
+
+
+def work_to_book(work: Work) -> Book:
+    author = (
+        creator_to_author(work.creators[0])
+        if work.creators
+        else Author("216", "Anonymous")
+    )
+    lcc_shelf = next((c.id for c in work.collections if c.kind == LCC_SHELF_KIND), None)
+    return Book(
+        book_id=int(work.id),
+        title=work.title,
+        subtitle=work.subtitle,
+        author=author,
+        languages=list(work.languages),
+        license=work.license or "Public domain in the USA.",
+        downloads=work.extra.get("downloads", 0),
+        lcc_shelf=lcc_shelf,
+        has_cover=work.extra.get("has_cover", work.cover is not None),
+        description=work.description,
+        unsupported_formats=list(work.extra.get("unsupported_formats", [])),
+        popularity=work.popularity or 0,
+        html_cover_path=work.cover.local_path if work.cover else None,
+        _cover_href=work.cover.source_url if work.cover else None,
+    )

--- a/scraper/src/gutenberg2zim/book_processor.py
+++ b/scraper/src/gutenberg2zim/book_processor.py
@@ -6,7 +6,10 @@ import apsw
 import backoff
 import requests
 
+from gutenberg2zim.adapters import book_to_work, work_to_book
 from gutenberg2zim.constants import logger
+from gutenberg2zim.core.work_store import WorkStore
+from gutenberg2zim.core.zim_assembler import ZimAssembler
 from gutenberg2zim.download import download_book
 from gutenberg2zim.export import (
     export_book,
@@ -14,7 +17,6 @@ from gutenberg2zim.export import (
     generate_json_files,
     generate_noscript_pages,
 )
-from gutenberg2zim.models import repository
 from gutenberg2zim.rdf import download_and_parse_book_rdf
 from gutenberg2zim.scraper_progress import ScraperProgress
 
@@ -29,6 +31,8 @@ def process_all_books(
     _languages: list[str],
     formats: list[str],
     progress: ScraperProgress,
+    work_store: WorkStore,
+    assembler: ZimAssembler,
     *,
     title_search: bool,
     add_lcc_shelves: bool,
@@ -41,7 +45,7 @@ def process_all_books(
 
     # Export infobox assets (CSS, JS, and icons) first to fail fast if there's an issue
     logger.info("Exporting infobox assets")
-    export_infobox_assets()
+    export_infobox_assets(assembler)
 
     logger.info(
         f"Processing {len(book_ids)} books with {concurrency} (parallel) worker(s)"
@@ -101,7 +105,7 @@ def process_all_books(
     def process_book_inner(book_id: int):
         """Download book content and export directly to ZIM with retry logic"""
 
-        book = download_and_parse_book_rdf(book_id, mirror_url)
+        book = download_and_parse_book_rdf(book_id, mirror_url, work_store)
         if not book:
             return
 
@@ -109,6 +113,7 @@ def process_all_books(
             mirror_url=mirror_url,
             book=book,
             formats=formats,
+            work_store=work_store,
         )
 
         if book_content:
@@ -117,6 +122,7 @@ def process_all_books(
                 book_files=book_content.files,
                 formats=formats,
                 mirror_url=mirror_url,
+                assembler=assembler,
                 _zim_name=zim_name,
                 _title_search=title_search,
                 _add_lcc_shelves=add_lcc_shelves,
@@ -127,7 +133,11 @@ def process_all_books(
     # Compute popularity (a bit too late for rendering on books pages,
     # but still useful for sorting)
     logger.info("Computing book popularity")
-    all_books = repository.get_all_books()
+    all_books = sorted(
+        (work_to_book(work) for work in work_store.works),
+        key=lambda book: book.downloads,
+        reverse=True,
+    )
 
     # Check if any books were successfully downloaded
     if not all_books:
@@ -156,12 +166,16 @@ def process_all_books(
         book.popularity = sum(
             [int(book.downloads >= stars_limits[i]) for i in range(NB_POPULARITY_STARS)]
         )
+        # Write the computed popularity back into the store
+        work_store.add(book_to_work(book))
 
     # export to JSON files (new format for Vue.js UI)
     logger.info("Generating JSON files for Vue.js UI")
     generate_json_files(
         zim_name=zim_name,
         formats=formats,
+        work_store=work_store,
+        assembler=assembler,
         title=title,
         description=description,
         add_lcc_shelves=add_lcc_shelves,
@@ -171,4 +185,8 @@ def process_all_books(
 
     # Generate No-JS fallback pages
     logger.info("Generating No-JS fallback pages")
-    generate_noscript_pages(formats=formats)
+    generate_noscript_pages(
+        formats=formats,
+        work_store=work_store,
+        assembler=assembler,
+    )

--- a/scraper/src/gutenberg2zim/config.py
+++ b/scraper/src/gutenberg2zim/config.py
@@ -1,0 +1,25 @@
+"""Explicit scrape configuration.
+
+Replaces the ad-hoc passing of CLI arguments through the call stack: the
+entrypoint builds one immutable `ScrapeConfig` and hands it to the pipeline,
+which forwards it (or parts of it) to the components that need it.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ScrapeConfig:
+    source: str
+    mirror_url: str
+    output_folder: Path
+    zim_file: Path
+    concurrency: int = 16
+    formats: list[str] = field(default_factory=lambda: ["epub", "pdf", "html"])
+    books: list[str] | None = None
+    languages: list[str] | None = None
+    collections: list[str] | None = None
+    ui_dist: Path | None = None
+    temp_dir: Path | None = None
+    debug: bool = False

--- a/scraper/src/gutenberg2zim/core/models.py
+++ b/scraper/src/gutenberg2zim/core/models.py
@@ -1,0 +1,64 @@
+"""Source-agnostic domain model.
+
+These dataclasses describe any book-like "work" independently of the source
+it came from (Project Gutenberg, Standard Ebooks, ...). Source-specific code
+converts its own metadata into these models; everything downstream (storage,
+export, ZIM assembly) only ever sees these types.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class Creator:
+    id: str
+    name: str
+    sort_name: str | None = None
+    birth_date: int | None = None
+    death_date: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class Format:
+    name: str
+    media_type: str
+    url: str | None = None
+    local_path: str | None = None
+    size: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Cover:
+    source_url: str | None = None
+    local_path: str | None = None
+    alt: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CollectionRef:
+    id: str
+    name: str
+    kind: str = "subject"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class Work:
+    id: str
+    source: str
+    title: str
+    subtitle: str | None = None
+    creators: list[Creator] = field(default_factory=list)
+    languages: list[str] = field(default_factory=list)
+    license: str | None = None
+    formats: list[Format] = field(default_factory=list)
+    cover: Cover | None = None
+    collections: list[CollectionRef] = field(default_factory=list)
+    popularity: int | None = None
+    description: str | None = None
+    published: date | None = None
+    source_url: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)

--- a/scraper/src/gutenberg2zim/core/work_store.py
+++ b/scraper/src/gutenberg2zim/core/work_store.py
@@ -1,0 +1,33 @@
+"""Explicit, thread-safe store for works.
+
+Replaces the global `BookRepository` singleton: callers receive a `WorkStore`
+instance instead of importing shared mutable state. Works are keyed by
+(source, id) so works from different sources never collide.
+"""
+
+import threading
+
+from gutenberg2zim.core.models import Work
+
+
+class WorkStore:
+    def __init__(self):
+        self._works: dict[tuple[str, str], Work] = {}
+        self._lock = threading.Lock()
+
+    def add(self, work: Work):
+        with self._lock:
+            self._works[(work.source, work.id)] = work
+
+    def get(self, source: str, work_id: str) -> Work | None:
+        with self._lock:
+            return self._works.get((source, work_id))
+
+    def remove(self, source: str, work_id: str):
+        with self._lock:
+            self._works.pop((source, work_id), None)
+
+    @property
+    def works(self) -> list[Work]:
+        with self._lock:
+            return list(self._works.values())

--- a/scraper/src/gutenberg2zim/core/zim_assembler.py
+++ b/scraper/src/gutenberg2zim/core/zim_assembler.py
@@ -1,0 +1,150 @@
+"""Explicit ZIM writer wrapping `zimscraperlib.Creator`.
+
+Replaces the `Global` static holder in `shared.py`: callers receive a
+`ZimAssembler` instance instead of reaching for shared mutable state. All
+write operations are serialized through an internal lock, so worker threads
+may add items concurrently.
+"""
+
+import pathlib
+import threading
+from datetime import date
+
+from zimscraperlib.zim.creator import Creator
+from zimscraperlib.zim.indexing import IndexData
+from zimscraperlib.zim.metadata import (
+    CreatorMetadata,
+    DateMetadata,
+    DefaultIllustrationMetadata,
+    DescriptionMetadata,
+    LanguageMetadata,
+    LongDescriptionMetadata,
+    NameMetadata,
+    PublisherMetadata,
+    ScraperMetadata,
+    StandardMetadataList,
+    TagsMetadata,
+    TitleMetadata,
+)
+
+from gutenberg2zim.constants import FAVICON_BYTES, VERSION, logger
+
+
+class ZimAssembler:
+    """Thread-safe wrapper around `zimscraperlib.Creator`."""
+
+    def __init__(
+        self,
+        *,
+        filename: pathlib.Path,
+        language: str | list[str],
+        title: str,
+        description: str,
+        name: str,
+        publisher: str,
+        source_creator: str,
+        tags: str,
+        long_description: str | None = None,
+        scraper_name: str | None = None,
+        with_fulltext_index: bool = True,
+        debug: bool = False,
+    ):
+        self._lock = threading.Lock()
+        self._creator = (
+            Creator(
+                filename=filename,
+                main_path="index.html",
+                workaround_nocancel=False,
+            )
+            .config_metadata(
+                std_metadata=StandardMetadataList(
+                    Title=TitleMetadata(title),
+                    Description=DescriptionMetadata(description),
+                    LongDescription=(
+                        LongDescriptionMetadata(long_description)
+                        if long_description and long_description.strip()
+                        else None
+                    ),
+                    Creator=CreatorMetadata(source_creator),
+                    Publisher=PublisherMetadata(publisher),
+                    Name=NameMetadata(name),
+                    Language=LanguageMetadata(language),
+                    Tags=TagsMetadata(tags),
+                    Scraper=ScraperMetadata(scraper_name or f"gutenberg2zim-{VERSION}"),
+                    Date=DateMetadata(date.today()),
+                    Illustration_48x48_at_1=DefaultIllustrationMetadata(FAVICON_BYTES),
+                )
+            )
+            .config_verbose(debug)
+            .config_indexing(with_fulltext_index)
+        )
+
+    @property
+    def can_finish(self) -> bool:
+        return self._creator.can_finish
+
+    @can_finish.setter
+    def can_finish(self, value: bool):
+        self._creator.can_finish = value
+
+    def start(self):
+        self._creator.start()
+
+    def add_item_for(
+        self,
+        path: str,
+        title: str | None = None,
+        fpath: pathlib.Path | None = None,
+        content: str | bytes | None = None,
+        mimetype: str | None = None,
+        *,
+        is_front: bool | None = None,
+        should_compress: bool | None = None,
+        delete_fpath: bool | None = False,
+        auto_index: bool = False,
+        index_data: IndexData | None = None,
+    ):
+        logger.debug(f"\t\tAdding ZIM item at {path}")
+
+        if not mimetype and path.endswith(".epub"):
+            mimetype = "application/epub+zip"
+
+        with self._lock:
+            self._creator.add_item_for(
+                path=path,
+                title=title,
+                fpath=fpath,
+                content=content,
+                mimetype=mimetype,
+                is_front=is_front,
+                should_compress=should_compress,
+                delete_fpath=delete_fpath,
+                auto_index=auto_index,
+                index_data=index_data,
+            )
+
+    def add_illustration(self, illus_fpath: pathlib.Path, illus_size: int):
+        with open(illus_fpath, "rb") as fh:
+            with self._lock:
+                self._creator.add_illustration(illus_size, fh.read())
+
+    def add_alias(self, path: str, title: str, target: str):
+        """Add a ZIM alias from path to target (for images/data, not HTML)"""
+        logger.debug(f"\t\tAdding ZIM alias from {path} to {target}")
+        with self._lock:
+            self._creator.add_alias(
+                path=path,
+                title=title,
+                targetPath=target,
+                hints={},
+            )
+
+    def finish(self):
+        if self._creator.can_finish:
+            logger.info("Finishing ZIM file")
+            with self._lock:
+                self._creator.finish()
+            logger.info(
+                f"Finished Zim {self._creator.filename.name} "
+                f"in {self._creator.filename.parent}"
+            )

--- a/scraper/src/gutenberg2zim/download.py
+++ b/scraper/src/gutenberg2zim/download.py
@@ -5,12 +5,14 @@ from pathlib import Path
 
 import requests
 
+from gutenberg2zim.adapters import GUTENBERG_SOURCE
 from gutenberg2zim.constants import (
     DEFAULT_HTTP_TIMEOUT,
     DL_CHUNCK_SIZE,
     logger,
 )
-from gutenberg2zim.models import Book, repository
+from gutenberg2zim.core.work_store import WorkStore
+from gutenberg2zim.models import Book
 from gutenberg2zim.pg_archive_urls import url_for_type
 from gutenberg2zim.utils import (
     ALL_FORMATS,
@@ -103,6 +105,7 @@ def download_book(
     mirror_url: str,
     book: Book,
     formats: list[str],
+    work_store: WorkStore,
 ) -> BookContent | None:
     """Download a book in all requested formats and return in-memory content"""
     logger.debug(f"\tDownloading content files for Book #{book.book_id}")
@@ -173,7 +176,7 @@ def download_book(
         logger.warning(
             f"\t\tBook #{book.book_id} could not be downloaded in any format. "
         )
-        repository.remove_book(book.book_id)
+        work_store.remove(GUTENBERG_SOURCE, str(book.book_id))
         return None
 
     # Note: Cover image download moved to export_book to avoid downloading

--- a/scraper/src/gutenberg2zim/entrypoint.py
+++ b/scraper/src/gutenberg2zim/entrypoint.py
@@ -8,7 +8,10 @@ from zimscraperlib.image.probing import is_hex_color
 from zimscraperlib.inputs import compute_descriptions
 
 from gutenberg2zim import i18n
+from gutenberg2zim.adapters import GUTENBERG_SOURCE
+from gutenberg2zim.config import ScrapeConfig
 from gutenberg2zim.constants import VERSION, logger
+from gutenberg2zim.core.work_store import WorkStore
 from gutenberg2zim.csv_catalog import (
     download_csv_file,
     filter_books,
@@ -264,25 +267,38 @@ def main():
     # Build ZIM file
     logger.info("BUILDING ZIM")
 
-    build_zimfile(
-        output_folder=output_folder,
-        books=filtered_books,
+    config = ScrapeConfig(
+        source=GUTENBERG_SOURCE,
         mirror_url=mirror_url,
+        output_folder=output_folder,
+        zim_file=Path(zim_file) if zim_file else output_folder,
         concurrency=concurrency,
-        languages=book_languages,
-        zim_languages=(
-            [lang.strip() for lang in zim_languages.split(",")]
-            if (zim_languages := arguments.get("--zim-languages"))
-            else None
-        ),
         formats=formats,
-        is_selection=len(only_books_ids) > 0 or len(lcc_shelves or []) > 0,
+        books=[str(book_id) for book_id in only_books_ids] or None,
+        languages=book_languages,
+        collections=lcc_shelves,
+        ui_dist=ui_dist,
+        debug=debug,
+    )
+    work_store = WorkStore()
+
+    build_zimfile(
+        books=filtered_books,
+        config=config,
+        work_store=work_store,
         zim_file=zim_file,
         zim_name=zim_name,
         title=zim_title,
         description=description,
         long_description=long_description,
         publisher=publisher,
+        ui_dist=ui_dist,
+        zim_languages=(
+            [lang.strip() for lang in zim_languages.split(",")]
+            if (zim_languages := arguments.get("--zim-languages"))
+            else None
+        ),
+        is_selection=len(only_books_ids) > 0 or len(lcc_shelves or []) > 0,
         primary_color=primary_color,
         secondary_color=secondary_color,
         overwrite=overwrite,
@@ -290,8 +306,6 @@ def main():
         add_lcc_shelves=add_lcc_shelves,
         progress=progress,
         with_fulltext_index=with_fulltext_index,
-        debug=debug,
-        ui_dist=ui_dist,
     )
 
     # Final increase to indicate we are done

--- a/scraper/src/gutenberg2zim/export.py
+++ b/scraper/src/gutenberg2zim/export.py
@@ -18,10 +18,13 @@ from zimscraperlib.image.optimization import (
 )
 from zimscraperlib.zim.indexing import IndexData
 
+from gutenberg2zim.adapters import work_to_book
 from gutenberg2zim.constants import logger
+from gutenberg2zim.core.work_store import WorkStore
+from gutenberg2zim.core.zim_assembler import ZimAssembler
 from gutenberg2zim.download import download_book_cover
 from gutenberg2zim.iso639 import language_name
-from gutenberg2zim.models import Author, Book, repository
+from gutenberg2zim.models import Author, Book
 from gutenberg2zim.schemas import (
     Author as AuthorSchema,
 )
@@ -40,7 +43,6 @@ from gutenberg2zim.schemas import (
 from gutenberg2zim.schemas import (
     Book as BookSchema,
 )
-from gutenberg2zim.shared import Global
 from gutenberg2zim.utils import (
     UTF8,
     archive_name_for,
@@ -401,6 +403,7 @@ def export_book(
     book_files: dict[str, bytes],
     formats: list[str],
     mirror_url: str,
+    assembler: ZimAssembler,
     _zim_name: str,
     *,
     _title_search: bool,
@@ -411,6 +414,7 @@ def export_book(
         book=book,
         book_files=book_files,
         formats=formats,
+        assembler=assembler,
     )
 
     # Handle cover image
@@ -422,7 +426,7 @@ def export_book(
         logger.debug(
             f"Using HTML cover for book #{book.book_id}: {book.html_cover_path}"
         )
-        Global.add_alias(
+        assembler.add_alias(
             path=cover_path,
             title="",
             target=book.html_cover_path,
@@ -434,7 +438,7 @@ def export_book(
         if cover_image:
             logger.debug(f"Using downloaded cover for book #{book.book_id}")
             cover_image = optimize_content(book, cover_path, cover_image)
-            Global.add_item_for(
+            assembler.add_item_for(
                 path=cover_path,
                 content=cover_image,
                 mimetype="image/webp",
@@ -446,6 +450,7 @@ def handle_book_files(
     book: Book,
     book_files: dict[str, bytes],
     formats: list[str],
+    assembler: ZimAssembler,
 ):
     """Handle book files from in-memory content and add to ZIM"""
 
@@ -466,7 +471,7 @@ def handle_book_files(
             raise
 
         # Add the optimized HTML directly to ZIM
-        Global.add_item_for(
+        assembler.add_item_for(
             path=article_name,
             content=str(new_html),
             mimetype="text/html",
@@ -490,7 +495,7 @@ def handle_book_files(
                 content = book_files[book_filename]
                 if other_format == "epub":
                     content = optimize_epub_bytes(content, book)
-                Global.add_item_for(
+                assembler.add_item_for(
                     path=archive_name,
                     content=content,
                     is_front=False,
@@ -517,7 +522,7 @@ def handle_book_files(
                 new_html = update_html_for_static(
                     book=book, html_content=html_str, formats=formats
                 )
-                Global.add_item_for(
+                assembler.add_item_for(
                     path=filename,
                     content=str(new_html),
                     mimetype="text/html",
@@ -549,7 +554,7 @@ def handle_book_files(
                             f"{output_filename}"
                         )
 
-                Global.add_item_for(
+                assembler.add_item_for(
                     path=output_filename,
                     content=optimized_file_content,
                     is_front=False,
@@ -713,17 +718,22 @@ def optimize_epub_bytes(epub_bytes: bytes, book: Book) -> bytes:
     return optimized_bytes
 
 
+def _all_books(work_store: WorkStore) -> list[Book]:
+    """Get all works from the store, converted back to legacy Book objects"""
+    return [work_to_book(work) for work in work_store.works]
+
+
 def _lcc_shelf_list_for_books(books: Iterable[Book]):
     return sorted({book.lcc_shelf for book in books if book.lcc_shelf})
 
 
-def lcc_shelf_list():
-    return _lcc_shelf_list_for_books(repository.get_all_books())
+def lcc_shelf_list(work_store: WorkStore):
+    return _lcc_shelf_list_for_books(_all_books(work_store))
 
 
-def lcc_shelf_list_language(lang):
+def lcc_shelf_list_language(lang, work_store: WorkStore):
     return _lcc_shelf_list_for_books(
-        filter(lambda book: lang in book.languages, repository.get_all_books())
+        filter(lambda book: lang in book.languages, _all_books(work_store))
     )
 
 
@@ -741,9 +751,9 @@ def _build_author_books_map(books: Iterable[Book]) -> dict[str, list[Book]]:
 # JSON Generation Functions for Vue.js UI
 
 
-def _get_authors_with_books() -> list[Author]:
-    """Get only authors who have at least one book in the repository"""
-    all_books = repository.get_all_books()
+def _get_authors_with_books(work_store: WorkStore) -> list[Author]:
+    """Get only authors who have at least one book in the work store"""
+    all_books = _all_books(work_store)
     authors_dict = {book.author.gut_id: book.author for book in all_books}
     return list(authors_dict.values())
 
@@ -850,7 +860,9 @@ def _lcc_shelf_to_preview(shelf_code: str, all_books: list[Book]) -> LCCShelfPre
     )
 
 
-def add_index_entry(title: str, content: str, fname: str, vue_route: str) -> None:
+def add_index_entry(
+    title: str, content: str, fname: str, vue_route: str, assembler: ZimAssembler
+) -> None:
     """Add a custom item to the ZIM index with HTML redirect to Vue.js route.
 
     Args:
@@ -858,6 +870,7 @@ def add_index_entry(title: str, content: str, fname: str, vue_route: str) -> Non
         content: Content/description for search indexing
         fname: Filename for the index entry (e.g., "book_12345")
         vue_route: Vue.js route path (e.g., "book/12345")
+        assembler: The ZIM assembler to add the item to
     """
     redirect_url = f"../index.html#/{vue_route}"
     safe_title = escape(title)
@@ -870,7 +883,7 @@ def add_index_entry(title: str, content: str, fname: str, vue_route: str) -> Non
     )
 
     logger.debug(f"Adding {fname} to ZIM index")
-    Global.add_item_for(
+    assembler.add_item_for(
         title=title,
         path=f"index/{fname}",
         content=html_content,
@@ -882,6 +895,8 @@ def add_index_entry(title: str, content: str, fname: str, vue_route: str) -> Non
 def generate_json_files(
     zim_name: str,
     formats: list[str],
+    work_store: WorkStore,
+    assembler: ZimAssembler,
     title: str | None = None,
     description: str | None = None,
     *,
@@ -896,8 +911,8 @@ def generate_json_files(
     max_books_in_index = 10
 
     # Fetch data once and reuse
-    all_books = repository.get_all_books()
-    all_authors = _get_authors_with_books()
+    all_books = _all_books(work_store)
+    all_authors = _get_authors_with_books(work_store)
 
     # Build author stats once for O(1) lookups
     author_stats: dict[str, tuple[int, int]] = {}
@@ -912,7 +927,7 @@ def generate_json_files(
         _book_to_preview(book, formats, author_stats) for book in all_books
     ]
     books_collection = Books(books=books_preview, total_count=len(books_preview))
-    Global.add_item_for(
+    assembler.add_item_for(
         path="books.json",
         content=books_collection.model_dump_json(by_alias=True, indent=2),
         mimetype="application/json",
@@ -926,7 +941,7 @@ def generate_json_files(
     authors_collection = Authors(
         authors=authors_preview, total_count=len(authors_preview)
     )
-    Global.add_item_for(
+    assembler.add_item_for(
         path="authors.json",
         content=authors_collection.model_dump_json(by_alias=True, indent=2),
         mimetype="application/json",
@@ -937,12 +952,12 @@ def generate_json_files(
         logger.debug("Generating lcc_shelves.json")
         shelves_preview = [
             _lcc_shelf_to_preview(shelf_code, all_books)
-            for shelf_code in repository.get_lcc_shelves()
+            for shelf_code in _lcc_shelf_list_for_books(all_books)
         ]
         shelves_collection = LCCShelves(
             shelves=shelves_preview, total_count=len(shelves_preview)
         )
-        Global.add_item_for(
+        assembler.add_item_for(
             path="lcc_shelves.json",
             content=shelves_collection.model_dump_json(by_alias=True, indent=2),
             mimetype="application/json",
@@ -956,7 +971,7 @@ def generate_json_files(
         primary_color=primary_color,
         secondary_color=secondary_color,
     )
-    Global.add_item_for(
+    assembler.add_item_for(
         path="config.json",
         content=config.model_dump_json(by_alias=True, indent=2),
         mimetype="application/json",
@@ -967,7 +982,7 @@ def generate_json_files(
     logger.debug("Generating book detail files and index entries")
     for book in all_books:
         book_detail = _book_to_schema(book, formats)
-        Global.add_item_for(
+        assembler.add_item_for(
             path=f"books/{book.book_id}.json",
             content=book_detail.model_dump_json(by_alias=True, indent=2),
             mimetype="application/json",
@@ -991,6 +1006,7 @@ def generate_json_files(
             content=". ".join(index_parts) + ".",
             fname=f"book_{book.book_id}",
             vue_route=f"book/{book.book_id}",
+            assembler=assembler,
         )
 
     logger.debug("Generating author detail files and index entries")
@@ -1013,7 +1029,7 @@ def generate_json_files(
             book_count=len(author_books),
         )
 
-        Global.add_item_for(
+        assembler.add_item_for(
             path=f"authors/{author.gut_id}.json",
             content=author_detail.model_dump_json(by_alias=True, indent=2),
             mimetype="application/json",
@@ -1043,11 +1059,12 @@ def generate_json_files(
             content=". ".join(author_parts) + ".",
             fname=f"author_{author.gut_id}",
             vue_route=f"author/{author.gut_id}",
+            assembler=assembler,
         )
 
     if add_lcc_shelves:
         logger.debug("Generating LCC shelf detail files and index entries")
-        for shelf_code in repository.get_lcc_shelves():
+        for shelf_code in _lcc_shelf_list_for_books(all_books):
             shelf_books = [
                 _book_to_preview(book, formats, author_stats)
                 for book in all_books
@@ -1059,7 +1076,7 @@ def generate_json_files(
                 books=shelf_books,
                 book_count=len(shelf_books),
             )
-            Global.add_item_for(
+            assembler.add_item_for(
                 path=f"lcc_shelves/{shelf_code}.json",
                 content=shelf_detail.model_dump_json(by_alias=True, indent=2),
                 mimetype="application/json",
@@ -1089,6 +1106,7 @@ def generate_json_files(
                 content=". ".join(shelf_parts) + ".",
                 fname=f"lcc_shelf_{shelf_code}",
                 vue_route=f"lcc-shelf/{shelf_code}",
+                assembler=assembler,
             )
 
     # Add index entries for main listing pages
@@ -1098,6 +1116,7 @@ def generate_json_files(
         f"Search and filter by language, format, author, and more.",
         fname="books_list",
         vue_route="books",
+        assembler=assembler,
     )
 
     add_index_entry(
@@ -1106,22 +1125,24 @@ def generate_json_files(
         f"Discover books by your favorite authors.",
         fname="authors_list",
         vue_route="authors",
+        assembler=assembler,
     )
 
     if add_lcc_shelves:
-        shelves = repository.get_lcc_shelves()
+        shelves = _lcc_shelf_list_for_books(all_books)
         add_index_entry(
             title="LCC Shelves - Project Gutenberg",
             content=f"Browse books by Library of Congress Classification. "
             f"{len(shelves)} shelves available covering various subjects and topics.",
             fname="lcc_shelves_list",
             vue_route="lcc-shelves",
+            assembler=assembler,
         )
 
     logger.info("JSON file generation completed")
 
 
-def export_infobox_assets() -> None:
+def export_infobox_assets(assembler: ZimAssembler) -> None:
     """Export infobox CSS, JS, and icon files to ZIM"""
     templates_dir = Path(__file__).parent / "templates"
 
@@ -1140,7 +1161,7 @@ def export_infobox_assets() -> None:
             logger.warning(f"Infobox asset not found: {file_path}")
             continue
         logger.debug(f"Adding {zim_path} to ZIM")
-        Global.add_item_for(
+        assembler.add_item_for(
             path=zim_path,
             fpath=file_path,
             mimetype=mimetype,
@@ -1150,6 +1171,8 @@ def export_infobox_assets() -> None:
 
 def generate_noscript_pages(
     formats: list[str],
+    work_store: WorkStore,
+    assembler: ZimAssembler,
 ) -> None:
     """Generate No-JavaScript fallback HTML pages"""
     logger.info("Generating No-JS fallback pages")
@@ -1158,15 +1181,15 @@ def generate_noscript_pages(
     common_css_path = Path(__file__).parent / "templates" / "noscript" / "common.css"
     if common_css_path.exists():
         logger.debug("Adding noscript/common.css to ZIM")
-        Global.add_item_for(
+        assembler.add_item_for(
             path="noscript/common.css",
             fpath=common_css_path,
             mimetype="text/css",
             is_front=False,
         )
-    all_books = repository.get_all_books()
-    all_authors = _get_authors_with_books()
-    shelves = sorted(repository.get_lcc_shelves())
+    all_books = _all_books(work_store)
+    all_authors = _get_authors_with_books(work_store)
+    shelves = _lcc_shelf_list_for_books(all_books)
     shelf_books_map: dict[str, list[Book]] = {
         shelf_code: [book for book in all_books if book.lcc_shelf == shelf_code]
         for shelf_code in shelves
@@ -1179,7 +1202,7 @@ def generate_noscript_pages(
         books=all_books,
         formats=formats,
     )
-    Global.add_item_for(
+    assembler.add_item_for(
         path="noscript/books.html",
         content=books_html,
         mimetype="text/html",
@@ -1201,7 +1224,7 @@ def generate_noscript_pages(
         all_books=all_books,
         author_book_counts=author_book_counts,
     )
-    Global.add_item_for(
+    assembler.add_item_for(
         path="noscript/authors.html",
         content=authors_html,
         mimetype="text/html",
@@ -1221,7 +1244,7 @@ def generate_noscript_pages(
             for code in shelves
         ]
     )
-    Global.add_item_for(
+    assembler.add_item_for(
         path="noscript/lcc_shelves.html",
         content=shelves_html,
         mimetype="text/html",
@@ -1239,7 +1262,7 @@ def generate_noscript_pages(
             books=shelf_books,
             formats=formats,
         )
-        Global.add_item_for(
+        assembler.add_item_for(
             path=f"noscript/lcc_shelf_{shelf_code}.html",
             content=shelf_html,
             mimetype="text/html",
@@ -1256,7 +1279,7 @@ def generate_noscript_pages(
             book=book,
             formats=formats,
         )
-        Global.add_item_for(
+        assembler.add_item_for(
             path=f"noscript/book_{book.book_id}.html",
             content=book_html,
             mimetype="text/html",
@@ -1274,7 +1297,7 @@ def generate_noscript_pages(
             author=author,
             author_books=author_books,
         )
-        Global.add_item_for(
+        assembler.add_item_for(
             path=f"noscript/author_{author.gut_id}.html",
             content=author_html,
             mimetype="text/html",

--- a/scraper/src/gutenberg2zim/rdf.py
+++ b/scraper/src/gutenberg2zim/rdf.py
@@ -3,9 +3,11 @@ import re
 import requests
 from bs4 import BeautifulSoup, Tag
 
+from gutenberg2zim.adapters import GUTENBERG_SOURCE, book_to_work, work_to_book
 from gutenberg2zim.constants import DEFAULT_HTTP_TIMEOUT, logger
+from gutenberg2zim.core.work_store import WorkStore
 from gutenberg2zim.csv_catalog import transform_locc_code
-from gutenberg2zim.models import Author, Book, repository
+from gutenberg2zim.models import Author, Book
 from gutenberg2zim.utils import normalize
 
 
@@ -169,41 +171,20 @@ def clean_marc_notation(text: str) -> str:
     return re.sub(r"\$[a-z]\s*", "", text) if text else text
 
 
-def _save_rdf_in_repository(parser: RdfParser) -> None:
-    """Save parsed RDF data into the in-memory repository"""
-    # Get or create author
+def _save_rdf_in_work_store(parser: RdfParser, work_store: WorkStore) -> None:
+    """Save parsed RDF data into the work store"""
     if parser.author_id:
-        author = repository.get_author(parser.author_id)
-        if not author:
-            # Create new author
-            normalized_last = normalize(parser.last_name) if parser.last_name else None
-            author = Author(
-                gut_id=parser.author_id,
-                last_name=normalized_last or "Unknown",
-                first_names=normalize(parser.first_name) if parser.first_name else None,
-                birth_year=str(parser.birth_year) if parser.birth_year else None,
-                death_year=str(parser.death_year) if parser.death_year else None,
-            )
-            repository.add_author(author)
-        else:
-            # Update existing author with new data
-            if parser.last_name:
-                normalized_last = normalize(parser.last_name)
-                if normalized_last:
-                    author.last_name = normalized_last
-            if parser.first_name:
-                author.first_names = normalize(parser.first_name)
-            if parser.birth_year:
-                author.birth_year = str(parser.birth_year)
-            if parser.death_year:
-                author.death_year = str(parser.death_year)
+        normalized_last = normalize(parser.last_name) if parser.last_name else None
+        author = Author(
+            gut_id=parser.author_id,
+            last_name=normalized_last or "Unknown",
+            first_names=normalize(parser.first_name) if parser.first_name else None,
+            birth_year=str(parser.birth_year) if parser.birth_year else None,
+            death_year=str(parser.death_year) if parser.death_year else None,
+        )
     else:
         # No author, use Anonymous (gut_id=216)
-        author = repository.get_author("216")
-        if not author:
-            # Should not happen as repository initializes default authors
-            author = Author(gut_id="216", last_name="Anonymous")
-            repository.add_author(author)
+        author = Author(gut_id="216", last_name="Anonymous")
 
     # Create or update book
     normalized_title = normalize(parser.title.strip()) if parser.title else "Untitled"
@@ -221,15 +202,18 @@ def _save_rdf_in_repository(parser: RdfParser) -> None:
             normalize(parser.description.strip()) if parser.description else None
         ),
     )
-    repository.add_book(book)
+    work_store.add(book_to_work(book))
 
 
-def download_and_parse_book_rdf(book_id: int, mirror_url: str) -> Book | None:
+def download_and_parse_book_rdf(
+    book_id: int, mirror_url: str, work_store: WorkStore
+) -> Book | None:
     """Download and parse RDF for a single book from the mirror.
 
     Args:
         book_id: The Gutenberg book ID
         mirror_url: The mirror URL (e.g., "https://gutenberg.mirror.driftle.ss")
+        work_store: The store parsed works are added to
 
     Returns:
         Book object if successful, None only for expected unusable books
@@ -259,8 +243,9 @@ def download_and_parse_book_rdf(book_id: int, mirror_url: str) -> Book | None:
         return None
 
     # All good - save it and return
-    _save_rdf_in_repository(parser)
-    return repository.get_book(book_id)
+    _save_rdf_in_work_store(parser, work_store)
+    work = work_store.get(GUTENBERG_SOURCE, str(book_id))
+    return work_to_book(work) if work else None
 
 
 def get_formatted_number(num: str | None) -> str | None:

--- a/scraper/src/gutenberg2zim/utils.py
+++ b/scraper/src/gutenberg2zim/utils.py
@@ -8,8 +8,9 @@ import chardet
 import requests
 
 from gutenberg2zim.constants import DEFAULT_HTTP_TIMEOUT, DL_CHUNCK_SIZE, logger
+from gutenberg2zim.core.work_store import WorkStore
 from gutenberg2zim.iso639 import language_name
-from gutenberg2zim.models import Book, repository
+from gutenberg2zim.models import Book
 
 UTF8 = "utf-8"
 ALL_FORMATS = ["epub", "pdf", "html"]
@@ -84,12 +85,14 @@ def download_file(url: str, fpath: Path) -> bool:
         return False
 
 
-def get_langs_with_count(languages: list[str] | None) -> list[tuple[str, str, int]]:
-    """Get language counts with their names from singleton BookRepository"""
+def get_langs_with_count(
+    languages: list[str] | None, work_store: WorkStore
+) -> list[tuple[str, str, int]]:
+    """Get language counts with their names from the work store"""
     lang_count = {}
 
-    for book in repository.get_all_books():
-        for code in book.languages:
+    for work in work_store.works:
+        for code in work.languages:
             # if not appear in user request languages list, skip counting
             if languages and code not in languages:
                 continue
@@ -103,9 +106,11 @@ def get_langs_with_count(languages: list[str] | None) -> list[tuple[str, str, in
     ]
 
 
-def get_lang_groups() -> tuple[list[tuple[str, str, int]], list[tuple[str, str, int]]]:
-    """Split languages into main and other groups from singleton BookRepository"""
-    langs_wt_count = get_langs_with_count(None)
+def get_lang_groups(
+    work_store: WorkStore,
+) -> tuple[list[tuple[str, str, int]], list[tuple[str, str, int]]]:
+    """Split languages into main and other groups from the work store"""
+    langs_wt_count = get_langs_with_count(None, work_store)
     if len(langs_wt_count) <= NB_MAIN_LANGS:
         return langs_wt_count, []
     else:

--- a/scraper/src/gutenberg2zim/zim.py
+++ b/scraper/src/gutenberg2zim/zim.py
@@ -5,11 +5,13 @@ from pathlib import Path
 
 from gutenberg2zim import i18n
 from gutenberg2zim.book_processor import process_all_books
+from gutenberg2zim.config import ScrapeConfig
 from gutenberg2zim.constants import logger
+from gutenberg2zim.core.work_store import WorkStore
+from gutenberg2zim.core.zim_assembler import ZimAssembler
 from gutenberg2zim.csv_catalog import CatalogEntry
 from gutenberg2zim.iso639 import ISO_MATRIX, ISO_MATRIX_REV, ZIM_LANGUAGES_MAP
 from gutenberg2zim.scraper_progress import ScraperProgress
-from gutenberg2zim.shared import Global
 from gutenberg2zim.utils import get_zim_name
 
 
@@ -40,7 +42,7 @@ def get_zim_language_metadata(languages: list[str], books: list[CatalogEntry]):
     return sorted(language_counts, key=lambda lang: language_counts[lang], reverse=True)
 
 
-def export_ui_dist(ui_dist: Path, title: str) -> None:
+def export_ui_dist(ui_dist: Path, title: str, assembler: ZimAssembler) -> None:
     """Export Vue.js UI dist folder to ZIM file."""
     if not ui_dist.exists():
         raise FileNotFoundError(f"UI dist directory not found: {ui_dist}")
@@ -62,14 +64,14 @@ def export_ui_dist(ui_dist: Path, title: str) -> None:
                 html_content,
                 flags=re.IGNORECASE,
             )
-            Global.add_item_for(
+            assembler.add_item_for(
                 path=path,
                 content=new_html_content,
                 mimetype="text/html",
                 is_front=True,
             )
         else:
-            Global.add_item_for(
+            assembler.add_item_for(
                 path=path,
                 fpath=file,
                 is_front=False,
@@ -80,11 +82,8 @@ def export_ui_dist(ui_dist: Path, title: str) -> None:
 
 def build_zimfile(
     books: list[CatalogEntry],
-    output_folder: Path,
-    mirror_url: str,
-    concurrency: int,
-    languages: list[str],
-    formats: list[str],
+    config: ScrapeConfig,
+    work_store: WorkStore,
     zim_file: str | None,
     zim_name: str | None,
     title: str | None,
@@ -92,6 +91,7 @@ def build_zimfile(
     long_description: str | None,
     zim_languages: list[str] | None,
     publisher: str,
+    ui_dist: Path,
     *,
     primary_color: str | None = None,
     secondary_color: str | None = None,
@@ -101,11 +101,15 @@ def build_zimfile(
     add_lcc_shelves: bool,
     progress: ScraperProgress,
     with_fulltext_index: bool,
-    debug: bool,
-    ui_dist: Path,
 ) -> None:
-    """Build ZIM file using singleton BookRepository"""
+    """Build ZIM file from the works collected in the work store"""
     progress.increase_total(len(books))
+    output_folder = config.output_folder
+    mirror_url = config.mirror_url
+    concurrency = config.concurrency
+    languages = config.languages or []
+    formats = config.formats
+    debug = config.debug
     iso_languages = [ISO_MATRIX.get(lang, lang) for lang in languages]
 
     formats.sort()
@@ -150,7 +154,7 @@ def build_zimfile(
         logger.info(f"Removing existing ZIM file {zim_file}")
         zim_path.unlink(missing_ok=True)
 
-    Global.setup(
+    assembler = ZimAssembler(
         filename=zim_path,
         language=zim_languages or get_zim_language_metadata(languages, books),
         title=title,
@@ -158,11 +162,13 @@ def build_zimfile(
         long_description=long_description,
         name=zim_name,
         publisher=publisher,
+        source_creator="gutenberg.org",
+        tags="_category:gutenberg;gutenberg",
         with_fulltext_index=with_fulltext_index,
         debug=debug,
     )
 
-    Global.start()
+    assembler.start()
 
     try:
         process_all_books(
@@ -173,6 +179,8 @@ def build_zimfile(
             _languages=languages,
             formats=formats,
             progress=progress,
+            work_store=work_store,
+            assembler=assembler,
             title_search=title_search,
             add_lcc_shelves=add_lcc_shelves,
             title=title,
@@ -182,15 +190,15 @@ def build_zimfile(
         )
 
         # Export Vue.js UI dist folder
-        export_ui_dist(ui_dist, title)
+        export_ui_dist(ui_dist, title, assembler)
 
     except KeyboardInterrupt:
-        Global.creator.can_finish = False
+        assembler.can_finish = False
         logger.error("KeyboardInterrupt, exiting.")
         raise
     except Exception:
-        Global.creator.can_finish = False
+        assembler.can_finish = False
         logger.exception("Interrupting process due to error")
         raise
     else:
-        Global.finish()
+        assembler.finish()


### PR DESCRIPTION
### What's new:
Introduced the source-agnostic domain model and replaced global singletons with explicit context objects.

### Concrete changes

#### Created `core/models.py`

```python
from dataclasses import dataclass, field
from datetime import date
from typing import Any, Optional


@dataclass(frozen=True, slots=True)
class Creator:
    id: str
    name: str
    sort_name: Optional[str] = None
    birth_date: Optional[int] = None
    death_date: Optional[int] = None
    extra: dict[str, Any] = field(default_factory=dict)


@dataclass(frozen=True, slots=True)
class Format:
    name: str
    media_type: str
    url: Optional[str] = None
    local_path: Optional[str] = None
    size: Optional[int] = None


@dataclass(frozen=True, slots=True)
class Cover:
    source_url: Optional[str] = None
    local_path: Optional[str] = None
    alt: Optional[str] = None


@dataclass(frozen=True, slots=True)
class CollectionRef:
    id: str
    name: str
    kind: str = "subject"
    extra: dict[str, Any] = field(default_factory=dict)


@dataclass(slots=True)
class Work:
    id: str
    source: str
    title: str
    subtitle: Optional[str] = None
    creators: list[Creator] = field(default_factory=list)
    languages: list[str] = field(default_factory=list)
    license: Optional[str] = None
    formats: list[Format] = field(default_factory=list)
    cover: Optional[Cover] = None
    collections: list[CollectionRef] = field(default_factory=list)
    popularity: Optional[int] = None
    description: Optional[str] = None
    published: Optional[date] = None
    source_url: Optional[str] = None
    extra: dict[str, Any] = field(default_factory=dict)
```

#### Created `core/work_store.py`

```python
import threading


class WorkStore:
    def __init__(self):
        self._works: dict[tuple[str, str], Work] = {}
        self._lock = threading.Lock()

    def add(self, work: Work):
        with self._lock:
            self._works[(work.source, work.id)] = work

    def get(self, source: str, work_id: str) -> Work | None:
        return self._works.get((source, work_id))

    @property
    def works(self) -> list[Work]:
        return list(self._works.values())
```

#### Created `core/zim_assembler.py`

Wrapped `zimscraperlib.Creator` explicitly:

```python
class ZimAssembler:
    def __init__(self, config: ZimConfig):
        self._creator = Creator(...)

    def add_work(self, work: Work, ...):
        ...

    def add_ui_dist(self, ui_dist_path: Path):
        ...

    def finalize(self):
        self._creator.finish()
```

#### Created `config.py`

```python
@dataclass(frozen=True)
class ScrapeConfig:
    source: str
    mirror_url: str
    output_folder: Path
    zim_file: Path
    concurrency: int = 16
    formats: list[str] = field(default_factory=lambda: ["epub", "pdf", "html"])
    books: Optional[list[str]] = None
    languages: Optional[list[str]] = None
    collections: Optional[list[str]] = None
    ui_dist: Optional[Path] = None
    temp_dir: Optional[Path] = None
    debug: bool = False
```

#### Conversion helpers

```python
def book_to_work(book: Book) -> Work:
    ...

def work_to_book(work: Work) -> Book:
    ...
```

These allow gradual migration.

#### Updated callers

- `book_processor.py` receives `WorkStore` and `ZimAssembler` as arguments.
- `export.py` receives `ZimAssembler` as an argument.
- `rdf.py` returns `Work` objects instead of writing to the repository.
- `download.py` receives the store and engine as arguments.

Everything works as it is