### PR TITLE
Centralize source-specific CLI option validation

### DIFF
--- a/scraper/src/gutenberg2zim/cli.py
+++ b/scraper/src/gutenberg2zim/cli.py
@@ -12,7 +12,11 @@ from gutenberg2zim.constants import VERSION
 from gutenberg2zim.orchestrator import run_scrape
 from gutenberg2zim.sources.registry import SOURCES
 
-source_options_help = "\n".join(profile.cli_options for profile in SOURCES.values())
+source_options_help = "\n".join(
+    option_help
+    for profile in SOURCES.values()
+    for option_help in profile.cli_options.values()
+)
 
 help_info = f"""Usage: gutenberg2zim [options]
 
@@ -32,7 +36,7 @@ Options:
   -c --concurrency=<nb>           Concurrent processing tasks
   --no-index                      Disable the full-text index
   --title-search                  Enable title search
-  {source_options_help}
+{source_options_help}
   --stats-filename=<filename>     Progress JSON path
   --publisher=<publisher>         ZIM publisher [default: openZIM]
   --mirror-url=<mirror_url>       Source mirror URL

--- a/scraper/src/gutenberg2zim/cli.py
+++ b/scraper/src/gutenberg2zim/cli.py
@@ -23,7 +23,8 @@ help_info = f"""Usage: gutenberg2zim [options]
 Options:
   -h --help                       Display this help message
   --overwrite                     Overwrite ZIM file if target already exists
-  --source=<source>               Source slug [default: gutenberg]
+  --source=<source>               Source slug or short name: gutenberg (PG),
+                                  opentextbooks (OTL) [default: gutenberg]
   -l --languages=<list>           Comma-separated language codes
   -f --formats=<list>             Formats: epub, html, pdf, or all
   -z --zim-file=<file>            ZIM output path

--- a/scraper/src/gutenberg2zim/config.py
+++ b/scraper/src/gutenberg2zim/config.py
@@ -14,7 +14,7 @@ from zimscraperlib.image.probing import is_hex_color
 from zimscraperlib.inputs import compute_descriptions
 
 from gutenberg2zim.core.utils import ALL_FORMATS, critical_error
-from gutenberg2zim.sources.registry import get_source
+from gutenberg2zim.sources.registry import SOURCES, SourceProfile, get_source
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,11 +56,29 @@ def _validate_colors(primary_color: str | None, secondary_color: str | None) -> 
         critical_error(f"--secondary-color is not a valid hex color: {secondary_color}")
 
 
+def _was_option_supplied(value: object) -> bool:
+    """Return whether a docopt option has a value other than its absent default."""
+    return value is not None and value is not False
+
+
+def _validate_source_cli_options(
+    arguments: dict[str, Any], selected_source: SourceProfile
+) -> None:
+    """Reject custom CLI options declared by a source other than the selected one."""
+    for profile in SOURCES.values():
+        if profile.slug == selected_source.slug:
+            continue
+        for option in profile.cli_options:
+            if _was_option_supplied(arguments.get(option)):
+                critical_error(f"{option} belongs to --source {profile.slug}")
+
+
 def build_scrape_config(arguments: dict) -> ScrapeConfig:
     """Turn parsed CLI arguments (docopt result) into a `ScrapeConfig`"""
     zim_file = arguments.get("--zim-file")
     zim_name = arguments.get("--zim-name")
     source = get_source(arguments.get("--source") or "gutenberg")
+    _validate_source_cli_options(arguments, source)
     source_options = source.parse_cli_options(arguments)
     mirror_url = arguments.get("--mirror-url") or source.default_mirror_url
 

--- a/scraper/src/gutenberg2zim/sources/gutenberg/cli.py
+++ b/scraper/src/gutenberg2zim/sources/gutenberg/cli.py
@@ -46,16 +46,15 @@ SUPPORTED_LCC_SHELVES = {
     "Z",
 }
 
-OPTIONS = (
-    "--lcc-shelves=<shelves>         Comma-separated LCC shelf codes to include "
-    "(e.g., P,PR,Q). Use 'all' for every shelf"
-)
+CLI_OPTIONS = {
+    "--lcc-shelves": (
+        "  --lcc-shelves=<shelves>         Comma-separated LCC shelf codes to "
+        "include (e.g., P,PR,Q). Use 'all' for every shelf"
+    ),
+}
 
 
 def parse_options(arguments: dict[str, Any]) -> dict[str, Any]:
-    for option in ("--subjects", "--otl-ids", "--list-subjects", "--refresh-catalog"):
-        if arguments.get(option):
-            critical_error(f"{option} belongs to --source opentextbooks")
     lcc_shelves_arg = arguments.get("--lcc-shelves")
     if lcc_shelves_arg is None:
         return {}

--- a/scraper/src/gutenberg2zim/sources/opentextbooks/cli.py
+++ b/scraper/src/gutenberg2zim/sources/opentextbooks/cli.py
@@ -5,19 +5,19 @@ from typing import Any
 
 from gutenberg2zim.core.utils import critical_error
 
-OPTIONS = "\n".join(
-    (
-        "  --subjects=<subjects>           Comma-separated Open Textbook Library subjects",  # noqa: E501
-        "  --otl-ids=<ids>                Exact Open Textbook Library record IDs",
-        "  --list-subjects                List Open Textbook Library subjects and exit",
-        "  --refresh-catalog              Refresh the Open Textbook Library CSV catalog and exit",  # noqa: E501
-    )
-)
+CLI_OPTIONS = {
+    "--subjects": "  --subjects=<subjects>           Comma-separated Open Textbook Library subjects",  # noqa: E501
+    "--otl-ids": (
+        "  --otl-ids=<ids>                Exact Open Textbook Library record IDs"
+    ),
+    "--list-subjects": (
+        "  --list-subjects                List Open Textbook Library subjects and exit"
+    ),
+    "--refresh-catalog": "  --refresh-catalog              Refresh the Open Textbook Library CSV catalog and exit",  # noqa: E501
+}
 
 
 def parse_options(arguments: dict[str, Any]) -> dict[str, Any]:
-    if arguments.get("--lcc-shelves") is not None:
-        critical_error("--lcc-shelves belongs to --source gutenberg")
     subjects = [
         item.strip()
         for item in (arguments.get("--subjects") or "").split(",")

--- a/scraper/src/gutenberg2zim/sources/registry.py
+++ b/scraper/src/gutenberg2zim/sources/registry.py
@@ -35,6 +35,7 @@ class SourceProfile:
     """Everything source-specific the source-agnostic layers need"""
 
     slug: str
+    aliases: tuple[str, ...]
     locale_namespace: str
     display_name: str
     # ZIM metadata values
@@ -63,6 +64,7 @@ class SourceProfile:
 
 GUTENBERG_PROFILE = SourceProfile(
     slug="gutenberg",
+    aliases=("PG",),
     locale_namespace="gutenberg",
     display_name="Project Gutenberg",
     source_creator="gutenberg.org",
@@ -86,6 +88,7 @@ GUTENBERG_PROFILE = SourceProfile(
 
 OPEN_TEXTBOOK_LIBRARY_PROFILE = SourceProfile(
     slug="opentextbooks",
+    aliases=("OTL",),
     locale_namespace="opentextbooks",
     display_name="Open Textbook Library",
     source_creator="open.umn.edu",
@@ -108,10 +111,18 @@ OPEN_TEXTBOOK_LIBRARY_PROFILE = SourceProfile(
 )
 
 SOURCES: dict[str, SourceProfile] = {}
+SOURCE_ALIASES: dict[str, SourceProfile] = {}
 
 
 def register_source(profile: SourceProfile) -> None:
     """Register (or replace) a source profile under its slug"""
+    source_key = profile.slug.casefold()
+    alias_keys = tuple(alias.casefold() for alias in profile.aliases)
+    if source_key != profile.slug:
+        raise ValueError(f"Source slug must be lowercase: {profile.slug}")
+    if len(alias_keys) != len(set(alias_keys)):
+        raise ValueError(f"Source {profile.slug} declares duplicate aliases")
+
     duplicate_options = set(profile.cli_options).intersection(
         option
         for existing_profile in SOURCES.values()
@@ -123,15 +134,53 @@ def register_source(profile: SourceProfile) -> None:
             f"Source {profile.slug} reuses custom CLI option(s): "
             f"{', '.join(sorted(duplicate_options))}"
         )
-    SOURCES[profile.slug] = profile
+
+    alias_owner = SOURCE_ALIASES.get(source_key)
+    if alias_owner and alias_owner.slug != profile.slug:
+        raise ValueError(
+            f"Source slug {profile.slug} conflicts with source alias "
+            f"registered for {alias_owner.slug}"
+        )
+    for alias, alias_key in zip(profile.aliases, alias_keys, strict=True):
+        if alias_key == source_key:
+            raise ValueError(
+                f"Source {profile.slug} cannot use its own slug as an alias"
+            )
+        slug_owner = SOURCES.get(alias_key)
+        if slug_owner and slug_owner.slug != profile.slug:
+            raise ValueError(
+                f"Source alias {alias} conflicts with source slug {slug_owner.slug}"
+            )
+        existing_profile = SOURCE_ALIASES.get(alias_key)
+        if existing_profile and existing_profile.slug != profile.slug:
+            raise ValueError(
+                f"Source alias {alias} is already registered for "
+                f"{existing_profile.slug}"
+            )
+
+    for alias_key, existing_profile in tuple(SOURCE_ALIASES.items()):
+        if existing_profile.slug == profile.slug:
+            del SOURCE_ALIASES[alias_key]
+    SOURCES[source_key] = profile
+    for alias_key in alias_keys:
+        SOURCE_ALIASES[alias_key] = profile
 
 
 def get_source(slug: str) -> SourceProfile:
-    """Return the profile registered for `slug`, aborting on unknown slugs"""
-    profile = SOURCES.get(slug)
+    """Return the profile registered for a source slug or case-insensitive alias."""
+    source_key = slug.casefold()
+    profile = SOURCES.get(source_key) or SOURCE_ALIASES.get(source_key)
     if profile is None:
+        available_sources = ", ".join(
+            (
+                f"{registered.slug} ({', '.join(registered.aliases)})"
+                if registered.aliases
+                else registered.slug
+            )
+            for registered in SOURCES.values()
+        )
         critical_error(
-            f"Unknown source: {slug}. Available sources: {', '.join(sorted(SOURCES))}"
+            f"Unknown source: {slug}. Available sources: {available_sources}"
         )
     return profile
 

--- a/scraper/src/gutenberg2zim/sources/registry.py
+++ b/scraper/src/gutenberg2zim/sources/registry.py
@@ -12,7 +12,7 @@ implementations, which keeps `core/` source-free while letting the type
 checker verify each profile against the port contracts at registration time.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -50,7 +50,7 @@ class SourceProfile:
     # URL path (relative to the mirror) of the catalog feed
     catalog_feed_path: str
     catalog: Any
-    cli_options: str
+    cli_options: Mapping[str, str]
     parse_cli_options: Callable[[dict[str, Any]], dict[str, Any]]
     handle_cli_action: Callable[[Any, dict[str, Any]], bool]
     pipeline_options: Callable[[str, Path | None], dict[str, Any]]
@@ -75,7 +75,7 @@ GUTENBERG_PROFILE = SourceProfile(
     default_mirror_url="https://gutenberg.mirror.driftle.ss",
     catalog_feed_path="/cache/epub/feeds/pg_catalog.csv.gz",
     catalog=gutenberg_catalog,
-    cli_options=gutenberg_cli.OPTIONS,
+    cli_options=gutenberg_cli.CLI_OPTIONS,
     parse_cli_options=gutenberg_cli.parse_options,
     handle_cli_action=gutenberg_cli.handle_cli_action,
     pipeline_options=lambda mirror_url, _cache_dir: {"mirror_url": mirror_url},
@@ -98,7 +98,7 @@ OPEN_TEXTBOOK_LIBRARY_PROFILE = SourceProfile(
     default_mirror_url="https://open.umn.edu/opentextbooks",
     catalog_feed_path="",
     catalog=OpenTextbookLibraryCatalog,
-    cli_options=opentextbooks_cli.OPTIONS,
+    cli_options=opentextbooks_cli.CLI_OPTIONS,
     parse_cli_options=opentextbooks_cli.parse_options,
     handle_cli_action=opentextbooks_cli.handle_cli_action,
     pipeline_options=lambda _mirror_url, cache_dir: {"cache_dir": cache_dir},
@@ -112,6 +112,17 @@ SOURCES: dict[str, SourceProfile] = {}
 
 def register_source(profile: SourceProfile) -> None:
     """Register (or replace) a source profile under its slug"""
+    duplicate_options = set(profile.cli_options).intersection(
+        option
+        for existing_profile in SOURCES.values()
+        if existing_profile.slug != profile.slug
+        for option in existing_profile.cli_options
+    )
+    if duplicate_options:
+        raise ValueError(
+            f"Source {profile.slug} reuses custom CLI option(s): "
+            f"{', '.join(sorted(duplicate_options))}"
+        )
     SOURCES[profile.slug] = profile
 
 

--- a/scraper/tests/test_config.py
+++ b/scraper/tests/test_config.py
@@ -16,6 +16,11 @@ def test_subjects_are_rejected_for_gutenberg():
         build_scrape_config({"--source": "gutenberg", "--subjects": "Mathematics"})
 
 
+def test_empty_foreign_source_option_is_rejected():
+    with pytest.raises(CriticalError, match="belongs to --source opentextbooks"):
+        build_scrape_config({"--source": "gutenberg", "--subjects": ""})
+
+
 def test_subjects_are_stored_for_opentextbooks():
     config = build_scrape_config(
         {

--- a/scraper/tests/test_source_registry.py
+++ b/scraper/tests/test_source_registry.py
@@ -1,9 +1,55 @@
 """Tests for static source-profile registration."""
 
+from dataclasses import replace
+
+import pytest
+
 from gutenberg2zim.core.ports import CatalogPort
+from gutenberg2zim.sources import registry
 from gutenberg2zim.sources.opentextbooks.catalog import OpenTextbookLibraryCatalog
 from gutenberg2zim.sources.opentextbooks.metadata import OpenTextbookLibraryMetadata
 from gutenberg2zim.sources.registry import get_source
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    monkeypatch.setattr(registry, "SOURCES", {})
+    monkeypatch.setattr(registry, "SOURCE_ALIASES", {})
+    return registry
+
+
+def _profile(slug: str, aliases: tuple[str, ...]):
+    return replace(
+        registry.GUTENBERG_PROFILE,
+        slug=slug,
+        aliases=aliases,
+        cli_options={},
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_name", "source_slug"),
+    (("PG", "gutenberg"), ("pg", "gutenberg"), ("OTL", "opentextbooks")),
+)
+def test_source_short_names_resolve_case_insensitively(source_name, source_slug):
+    assert get_source(source_name).slug == source_slug
+
+
+def test_register_source_rejects_slug_that_conflicts_with_an_alias(isolated_registry):
+    isolated_registry.register_source(_profile("first", ("other",)))
+
+    with pytest.raises(ValueError, match="Source slug other conflicts"):
+        isolated_registry.register_source(_profile("other", ()))
+
+
+def test_replacing_source_removes_its_previous_aliases(isolated_registry):
+    isolated_registry.register_source(_profile("first", ("old",)))
+    replacement = _profile("first", ("new",))
+
+    isolated_registry.register_source(replacement)
+
+    assert "old" not in isolated_registry.SOURCE_ALIASES
+    assert isolated_registry.get_source("new") is replacement
 
 
 def test_opentextbooks_profile_is_registered_with_its_json_adapters():


### PR DESCRIPTION
## Improve source-specific CLI options

Source-specific CLI options are now declared by their owning source and validated centrally. This removes cross-source option checks from individual source parsers and makes additional sources easier to add.

The CLI now rejects options that belong to a different selected source, including explicitly empty values. Duplicate custom option declarations are rejected during source registration.

Short source aliases are also supported:

```bash
gutenberg2zim --source PG
gutenberg2zim --source OTL
```

Fixes #529 
Fixes #528 