### PR TITLE
Add end-to-end scraper integration tests

### DIFF
--- a/.github/workflows/DailyTests.yaml
+++ b/.github/workflows/DailyTests.yaml
@@ -1,97 +1,14 @@
-name: Tests
+name: Daily tests
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
 
 jobs:
-  test-scraper:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: scraper/pyproject.toml
-          architecture: x64
-
-      - name: Install dependencies (and project)
-        working-directory: scraper
-        run: |
-          pip install -U pip
-          pip install -e .[test,scripts]
-
-      - name: Run the tests
-        working-directory: scraper
-        run: inv coverage --args "-vvv"
-
-      - name: Upload coverage report to codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  build-scraper:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: scraper/pyproject.toml
-          architecture: x64
-
-      - name: Ensure we can build Python targets
-        working-directory: scraper
-        run: |
-          pip install -U pip build
-          python3 -m build --sdist --wheel
-
-  build-and-test-zimui:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: "ui/package.json"
-
-      - name: Install dependencies
-        working-directory: ui
-        run: |
-          npm ci
-
-      - name: Generate language names
-        working-directory: ui
-        run: |
-          npm run generate
-
-      - name: Test
-        working-directory: ui
-        run: |
-          npm run test:unit
-          npm run test:integration
-
-      - name: Build
-        working-directory: ui
-        run: |
-          npm run build
-
-      - name: Start web server
-        working-directory: ui
-        run: |
-          npm run preview &
-
-      - name: Wait for web server to be ready
-        run: |
-          npx wait-on http://localhost:5173
-
   run-integration-tests:
     runs-on: ubuntu-24.04
+
     steps:
       - uses: actions/checkout@v6
 
@@ -149,4 +66,4 @@ jobs:
         with:
           name: integration-zims
           path: output/*.zim
-          retention-days: 7
+          retention-days: 30

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -205,6 +205,7 @@ ban-relative-imports = "all"
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+"tests-integration/**/*" = ["PLR2004", "S101", "TID252"]
 # Standalone scripts report to stdout
 "scripts/**/*" = ["T201"]
 

--- a/scraper/src/gutenberg2zim/core/exporters/ui_dist_exporter.py
+++ b/scraper/src/gutenberg2zim/core/exporters/ui_dist_exporter.py
@@ -4,7 +4,7 @@ import re
 from html import escape
 from pathlib import Path
 
-from gutenberg2zim.constants import logger
+from gutenberg2zim.constants import FAVICON_BYTES, logger
 from gutenberg2zim.core.zim_assembler import ZimAssembler
 
 
@@ -15,10 +15,12 @@ def export_ui_dist(ui_dist: Path, title: str, assembler: ZimAssembler) -> None:
 
     logger.info(f"Adding Vue.js UI files from {ui_dist}")
     file_count = 0
+    has_favicon = False
     for file in ui_dist.rglob("*"):
         if file.is_dir():
             continue
         path = file.relative_to(ui_dist).as_posix()
+        has_favicon = has_favicon or path == "favicon.png"
         logger.debug(f"Adding {path} to ZIM")
 
         # Update index.html title
@@ -42,5 +44,13 @@ def export_ui_dist(ui_dist: Path, title: str, assembler: ZimAssembler) -> None:
                 fpath=file,
                 is_front=False,
             )
+        file_count += 1
+    if not has_favicon:
+        assembler.add_item_for(
+            path="favicon.png",
+            content=FAVICON_BYTES,
+            mimetype="image/png",
+            is_front=False,
+        )
         file_count += 1
     logger.info(f"Successfully added {file_count} UI files to ZIM")

--- a/scraper/src/gutenberg2zim/templates/noscript/book.html
+++ b/scraper/src/gutenberg2zim/templates/noscript/book.html
@@ -57,11 +57,11 @@
         <h2>Available Formats</h2>
         {% for fmt in book.requested_formats(formats) %}
         {% if fmt == "html" %}
-        <a href="../{{ book|article_name_for }}" class="format-link">Read Online (HTML)</a>
+        <a href="../{{ book|article_name_for|urlencode }}" class="format-link">Read Online (HTML)</a>
         {% elif fmt == "epub" %}
-        <a href="../{{ book|archive_name_for("epub") }}" class="format-link">Download EPUB</a>
+        <a href="../{{ book|archive_name_for("epub")|urlencode }}" class="format-link">Download EPUB</a>
         {% elif fmt == "pdf" %}
-        <a href="../{{ book|archive_name_for("pdf") }}" class="format-link">Download PDF</a>
+        <a href="../{{ book|archive_name_for("pdf")|urlencode }}" class="format-link">Download PDF</a>
         {% endif %}
         {% endfor %}
     </div>

--- a/scraper/tests-integration/README.md
+++ b/scraper/tests-integration/README.md
@@ -1,0 +1,5 @@
+This folder contains end-to-end scraper tests. They build small ZIMs from live
+Project Gutenberg and Open Textbook Library records, then inspect the generated
+archives.
+
+The suite is designed to run from the scraper Docker image in GitHub Actions.

--- a/scraper/tests-integration/test_zim_content.py
+++ b/scraper/tests-integration/test_zim_content.py
@@ -1,0 +1,105 @@
+"""End-to-end checks for the small ZIMs produced in CI."""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from zimscraperlib.zim import Archive
+
+
+@dataclass(frozen=True)
+class ZimExpectation:
+    """Expected source data for one generated integration-test ZIM."""
+
+    filename: str
+    title: str
+    source_slug: str
+    source_creator: str
+    work_id: str
+    format_name: str
+    mimetype: str
+
+
+ZIM_EXPECTATIONS = (
+    ZimExpectation(
+        filename="gutenberg-integration.zim",
+        title="Gutenberg Test",
+        source_slug="gutenberg",
+        source_creator="gutenberg.org",
+        work_id="11",
+        format_name="html",
+        mimetype="text/html",
+    ),
+    ZimExpectation(
+        filename="opentextbooks-integration.zim",
+        title="OTL Test",
+        source_slug="opentextbooks",
+        source_creator="open.umn.edu",
+        work_id="54",
+        format_name="pdf",
+        mimetype="application/pdf",
+    ),
+)
+
+
+def _read_json(zim: Archive, path: str) -> dict:
+    item = zim.get_item(path)
+    assert item
+    assert item.mimetype == "application/json"
+    return json.loads(bytes(item.content))
+
+
+@pytest.fixture(params=ZIM_EXPECTATIONS, ids=lambda expected: expected.source_slug)
+def expected(request) -> ZimExpectation:
+    return request.param
+
+
+@pytest.fixture
+def zim_path(expected: ZimExpectation) -> Path:
+    return Path(os.environ["ZIM_DIRECTORY"]) / expected.filename
+
+
+@pytest.fixture
+def zim(zim_path: Path) -> Archive:
+    assert zim_path.is_file()
+    return Archive(zim_path)
+
+
+def test_zim_metadata_and_main_page(zim: Archive, expected: ZimExpectation):
+    """The generated archive identifies its source and opens the UI."""
+    assert zim.main_entry.is_redirect
+    assert zim.main_entry.get_redirect_entry().path == "index.html"
+    assert zim.get_text_metadata("Title") == expected.title
+    assert zim.get_text_metadata("Creator") == expected.source_creator
+    assert zim.get_text_metadata("Publisher") == "openZIM"
+    assert "gutenberg2zim-" in zim.get_text_metadata("Scraper")
+    favicon = zim.get_item("favicon.png")
+    assert favicon
+    assert favicon.mimetype == "image/png"
+    assert len(favicon.content) > 0
+
+
+def test_zim_contains_the_selected_work(zim: Archive, expected: ZimExpectation):
+    """The UI data and requested source edition are present and readable."""
+    config = _read_json(zim, "config.json")
+    books = _read_json(zim, "books.json")
+    book = _read_json(zim, f"books/{expected.work_id}.json")
+
+    assert config["source"]["slug"] == expected.source_slug
+    assert books["totalCount"] == 1
+    assert books["books"][0]["id"] == expected.work_id
+    assert books["books"][0]["availableFormats"] == [expected.format_name]
+    assert book["id"] == expected.work_id
+
+    (format_info,) = [
+        format_info
+        for format_info in book["formats"]
+        if format_info["format"] == expected.format_name
+    ]
+    assert format_info["available"] is True
+    edition = zim.get_item(format_info["path"])
+    assert edition
+    assert edition.mimetype == expected.mimetype
+    assert len(edition.content) > 0

--- a/scraper/tests/test_nojs_exporter.py
+++ b/scraper/tests/test_nojs_exporter.py
@@ -48,3 +48,29 @@ def test_collection_pages_use_configured_label_and_collection_name():
     assert 'name="viewport"' in detail["content"]
     assert detail["title"] == "Subjects: Computer Science"
     assert "collection_Computer%2FScience.html" in listing["content"]
+
+
+def test_book_format_links_are_url_encoded():
+    assembler = MagicMock(name="assembler")
+    store = WorkStore()
+    store.add(
+        Work(
+            id="11",
+            source="gutenberg",
+            title="Alice's Adventures in Wonderland",
+            creators=[Creator(id="1", name="Lewis Carroll")],
+        )
+    )
+
+    generate_noscript_pages(
+        formats=["html", "epub", "pdf"],
+        work_store=store,
+        assembler=assembler,
+        display_name="Project Gutenberg",
+        indexes=IndexBuilder(store).build(display_name="Project Gutenberg"),
+    )
+
+    page = _item_call(assembler, "noscript/book_11.html").kwargs["content"]
+    assert "Alice%27s%20Adventures%20in%20Wonderland.11" in page
+    assert "Alice%27s%20Adventures%20in%20Wonderland.11.epub" in page
+    assert "Alice%27s%20Adventures%20in%20Wonderland.11.pdf" in page

--- a/scraper/tests/test_ui_dist_exporter.py
+++ b/scraper/tests/test_ui_dist_exporter.py
@@ -1,0 +1,27 @@
+"""Tests for exporting the bundled UI into a ZIM."""
+
+from unittest.mock import MagicMock
+
+from gutenberg2zim.constants import FAVICON_BYTES
+from gutenberg2zim.core.exporters.ui_dist_exporter import export_ui_dist
+
+
+def test_exports_fallback_favicon_when_the_ui_build_has_none(tmp_path):
+    (tmp_path / "index.html").write_text(
+        "<html><head><title>Library</title></head></html>", encoding="utf-8"
+    )
+    assembler = MagicMock(name="assembler")
+
+    export_ui_dist(tmp_path, "Test Library", assembler)
+
+    favicon_call = next(
+        call
+        for call in assembler.add_item_for.call_args_list
+        if call.kwargs["path"] == "favicon.png"
+    )
+    assert favicon_call.kwargs == {
+        "path": "favicon.png",
+        "content": FAVICON_BYTES,
+        "mimetype": "image/png",
+        "is_front": False,
+    }


### PR DESCRIPTION
Adds a small end-to-end integration suite, following the Maps scraper pattern.

The suite builds and validates two minimal live ZIMs:

- Project Gutenberg: book-11 as HTML
- Open Textbook Library: book-54 as PDF

It verifies ZIM metadata, main-page routing, exported UI data, the selected book record, and the downloaded source edition. Both ZIMs are also checked with `zimcheck`.

Integration tests now run:

- on pull requests and pushes to `main` through the `run-integration-tests` job in `Tests.yaml`;
- daily at 04:00 UTC through `DailyTests.yaml`;
- manually through the daily workflow dispatch action.

Generated ZIMs are uploaded as workflow artifacts.

Fix #530 