### PR TITLE
Allow custom ZIM tags in recipes

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -91,6 +91,12 @@
       "pattern": "^[a-z]{3}(,[a-z]{3})*$",
       "customValidator": "language_code"
     },
+    "zim_tags": {
+      "type": "string",
+      "required": false,
+      "title": "ZIM Tags",
+      "description": "Semicolon-separated ZIM tags. Overrides the selected source's default tags; for example: _category:medical;gutenberg."
+    },
     "books": {
       "type": "string",
       "required": false,
@@ -200,6 +206,10 @@
     {
       "metadata": "Language",
       "flag": "zim_languages"
+    },
+    {
+      "metadata": "Tags",
+      "flag": "zim_tags"
     }
   ]
 }

--- a/scraper/src/gutenberg2zim/cli.py
+++ b/scraper/src/gutenberg2zim/cli.py
@@ -33,6 +33,7 @@ Options:
   -n --zim-desc=<description>     ZIM description
   -L --zim-long-desc=<description> ZIM long description
   --zim-languages=<languages>     ZIM language metadata
+  --zim-tags=<tags>               Semicolon-separated ZIM tags
   -b --books=<ids>                Source catalog positions or ranges
   -c --concurrency=<nb>           Concurrent processing tasks
   --no-index                      Disable the full-text index

--- a/scraper/src/gutenberg2zim/config.py
+++ b/scraper/src/gutenberg2zim/config.py
@@ -38,6 +38,7 @@ class ScrapeConfig:
     description: str | None = None
     long_description: str | None = None
     zim_languages: list[str] | None = None
+    zim_tags: str | None = None
     publisher: str = "openZIM"
     overwrite: bool = False
     is_selection: bool = False
@@ -193,6 +194,7 @@ def build_scrape_config(arguments: dict) -> ScrapeConfig:
             if (zim_languages := arguments.get("--zim-languages"))
             else None
         ),
+        zim_tags=(arguments.get("--zim-tags") or "").strip() or None,
         publisher=publisher,
         overwrite=overwrite,
         is_selection=bool(

--- a/scraper/src/gutenberg2zim/orchestrator.py
+++ b/scraper/src/gutenberg2zim/orchestrator.py
@@ -240,7 +240,7 @@ def build_zimfile(
         name=zim_name,
         publisher=publisher,
         source_creator=profile.source_creator,
-        tags=profile.zim_tags,
+        tags=config.zim_tags or profile.zim_tags,
         with_fulltext_index=with_fulltext_index,
         debug=debug,
     )

--- a/scraper/tests/test_config.py
+++ b/scraper/tests/test_config.py
@@ -52,6 +52,17 @@ def test_otl_only_arguments_are_rejected_for_gutenberg():
         build_scrape_config({"--source": "gutenberg", "--list-subjects": True})
 
 
+def test_zim_tags_override_source_defaults():
+    config = build_scrape_config(
+        {
+            "--source": "gutenberg",
+            "--zim-tags": " _category:medical;gutenberg ",
+        }
+    )
+
+    assert config.zim_tags == "_category:medical;gutenberg"
+
+
 def test_source_neutral_environment_variables_configure_output_and_ui(
     monkeypatch, tmp_path
 ):

--- a/scraper/tests/test_offliner_definition.py
+++ b/scraper/tests/test_offliner_definition.py
@@ -33,3 +33,18 @@ def test_recipe_uses_enum_choices_for_supported_formats():
     assert [
         choice["value"] for choice in definition["flags"]["formats"]["choices"]
     ] == ["epub", "html", "pdf"]
+
+
+def test_recipe_exposes_custom_zim_tags():
+    definition = json.loads(DEFINITION_PATH.read_text(encoding="utf-8"))
+
+    assert definition["flags"]["zim_tags"] == {
+        "type": "string",
+        "required": False,
+        "title": "ZIM Tags",
+        "description": (
+            "Semicolon-separated ZIM tags. Overrides the selected source's default "
+            "tags; for example: _category:medical;gutenberg."
+        ),
+    }
+    assert {"metadata": "Tags", "flag": "zim_tags"} in definition["zimMetadata"]


### PR DESCRIPTION
## Allow custom ZIM tags in recipes

Adds a source-agnostic `--zim-tags` option for setting ZIM metadata tags.

When omitted, each source retains its default tag set. When supplied, the value replaces that default, allowing Zimfarm recipes to define an appropriate category.

For example, a medical Project Gutenberg selection can use:

```text
_category:medical;gutenberg
```

Fixes #542 