### PR TITLE
refactor: centralize downloaded content validation

### DIFF
--- a/scraper/src/gutenberg2zim/core/content_validation.py
+++ b/scraper/src/gutenberg2zim/core/content_validation.py
@@ -1,0 +1,31 @@
+"""Validation helpers for downloaded source content."""
+
+from io import BytesIO
+from zipfile import BadZipFile, ZipFile
+
+
+def is_html_document(content: bytes) -> bool:
+    """Return whether downloaded content looks like an HTML document."""
+    stripped = content.lstrip().lower()
+    return stripped.startswith((b"<!doctype html", b"<html", b"<head", b"<body"))
+
+
+def is_valid_book_file(content: bytes, format_name: str) -> bool:
+    """Validate downloaded content independently of its HTTP metadata."""
+    if not content or is_html_document(content):
+        return False
+    if format_name == "pdf":
+        return content.lstrip().startswith(b"%PDF-")
+    if format_name == "epub":
+        try:
+            with ZipFile(BytesIO(content)) as archive:
+                if archive.testzip() is not None:
+                    return False
+                try:
+                    mimetype = archive.read("mimetype")
+                except KeyError:
+                    return False
+                return mimetype == b"application/epub+zip"
+        except BadZipFile:
+            return False
+    return False

--- a/scraper/src/gutenberg2zim/sources/opentextbooks/html_mirror.py
+++ b/scraper/src/gutenberg2zim/sources/opentextbooks/html_mirror.py
@@ -12,6 +12,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from gutenberg2zim.constants import logger
+from gutenberg2zim.core.content_validation import is_html_document
 from gutenberg2zim.core.download_engine import is_fatal_http_error
 from gutenberg2zim.core.models import Work
 from gutenberg2zim.core.rewriters.image_rewriter import ImageProcessor
@@ -508,12 +509,3 @@ def _asset_path(work: Work, url: str) -> str:
 
 def _is_css_url(url: str) -> bool:
     return urlparse(url).path.lower().endswith(".css")
-
-
-def is_html_document(content: bytes) -> bool:
-    prefix = content.lstrip()[:512].lower()
-    return (
-        prefix.startswith(b"<!doctype html")
-        or prefix.startswith(b"<html")
-        or b"<html" in prefix
-    )

--- a/scraper/src/gutenberg2zim/sources/opentextbooks/pipeline.py
+++ b/scraper/src/gutenberg2zim/sources/opentextbooks/pipeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import requests
 
 from gutenberg2zim.constants import logger
+from gutenberg2zim.core.content_validation import is_html_document, is_valid_book_file
 from gutenberg2zim.core.download_engine import DownloadEngine, is_fatal_http_error
 from gutenberg2zim.core.models import Cover, Work
 from gutenberg2zim.core.pipeline import Pipeline
@@ -17,7 +18,6 @@ from gutenberg2zim.sources.opentextbooks.covers import extract_cover, fetch_page
 from gutenberg2zim.sources.opentextbooks.html_mirror import (
     HtmlEdition,
     download_html_edition,
-    is_html_document,
     set_download_controls,
 )
 from gutenberg2zim.sources.opentextbooks.invalid_urls import InvalidEditionCache
@@ -193,7 +193,7 @@ class OpenTextbookLibraryPipeline(Pipeline):
             self.invalid_urls.add(url)
             unsupported.append(format_name)
             return
-        if not _is_valid_book_file(content, format_name):
+        if not is_valid_book_file(content, format_name):
             logger.warning(
                 "OTL textbook #%s returned a non-%s response for %s",
                 work.id,
@@ -225,14 +225,3 @@ class OpenTextbookLibraryPipeline(Pipeline):
         return future or self._cover_executor.submit(
             fetch_page_cover, self.engine, work.source_url
         )
-
-
-def _is_valid_book_file(content: bytes, format_name: str) -> bool:
-    """Reject landing pages masquerading as directly linked book files."""
-    if format_name == "pdf":
-        return content.lstrip().startswith(b"%PDF-")
-    if format_name == "epub":
-        return content.startswith(b"PK\x03\x04")
-    if format_name == "html":
-        return is_html_document(content)
-    return False

--- a/scraper/tests/test_content_validation.py
+++ b/scraper/tests/test_content_validation.py
@@ -1,0 +1,67 @@
+"""Tests for source-neutral downloaded-content validation."""
+
+from io import BytesIO
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pytest
+
+from gutenberg2zim.core.content_validation import is_html_document, is_valid_book_file
+
+
+def _zip_bytes(*files: tuple[str, bytes]) -> bytes:
+    output = BytesIO()
+    with ZipFile(output, "w", ZIP_DEFLATED) as archive:
+        for name, content in files:
+            archive.writestr(name, content)
+    return output.getvalue()
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        b"<!doctype html><html><body>Error</body></html>",
+        b"  <html><body>Access denied</body></html>",
+        b"<head><title>Not found</title></head>",
+    ],
+)
+def test_is_html_document_detects_html_error_pages(content: bytes):
+    assert is_html_document(content)
+
+
+def test_empty_content_is_invalid_for_book_formats():
+    assert not is_valid_book_file(b"", "pdf")
+    assert not is_valid_book_file(b"", "epub")
+
+
+def test_pdf_validation_uses_file_signature_not_content_type():
+    assert is_valid_book_file(b"%PDF-1.7\ncontent", "pdf")
+    assert not is_valid_book_file(b"not a pdf", "pdf")
+
+
+def test_html_error_page_is_rejected_even_when_format_is_pdf():
+    assert not is_valid_book_file(
+        b"<!doctype html><html><body>Temporary error</body></html>", "pdf"
+    )
+
+
+def test_epub_validation_accepts_a_valid_zip_container():
+    epub = _zip_bytes(("mimetype", b"application/epub+zip"))
+    assert is_valid_book_file(epub, "epub")
+
+
+def test_epub_validation_rejects_signature_only_data():
+    assert not is_valid_book_file(b"PK\x03\x04", "epub")
+
+
+def test_epub_validation_rejects_arbitrary_non_epub_binary():
+    arbitrary_zip = _zip_bytes(("README.txt", b"not an ebook"))
+    assert not is_valid_book_file(arbitrary_zip, "epub")
+
+
+def test_epub_validation_rejects_corrupt_zip_data():
+    valid_zip = _zip_bytes(("mimetype", b"application/epub+zip"))
+    assert not is_valid_book_file(valid_zip[:-4], "epub")
+
+
+def test_unknown_format_is_rejected():
+    assert not is_valid_book_file(b"some content", "mobi")

--- a/scraper/tests/test_otl_pipeline.py
+++ b/scraper/tests/test_otl_pipeline.py
@@ -1,6 +1,8 @@
 """Tests for OTL per-work processing."""
 
+from io import BytesIO
 from unittest.mock import MagicMock, patch
+from zipfile import ZIP_STORED, ZipFile
 
 from gutenberg2zim.core.models import Format, Work
 from gutenberg2zim.core.ports import WorkRef
@@ -25,6 +27,13 @@ def _pipeline(work: Work, engine: MagicMock, assembler: MagicMock):
         title_search=False,
         engine=engine,
     )
+
+
+def _valid_epub() -> bytes:
+    output = BytesIO()
+    with ZipFile(output, "w", ZIP_STORED) as archive:
+        archive.writestr("mimetype", "application/epub+zip")
+    return output.getvalue()
 
 
 def test_process_ref_exports_direct_files_and_marks_unavailable_formats():
@@ -197,12 +206,10 @@ def test_html_is_not_mirrored_when_a_binary_format_is_available_after_it():
     pipeline.formats = ["html", "pdf"]
     edition = MagicMock(pages={"Calculus.10": b"<!doctype html><html></html>"})
 
-    with (
-        patch(
-            "gutenberg2zim.sources.opentextbooks.pipeline.download_html_edition",
-            return_value=edition,
-        ) as mirror,
-    ):
+    with patch(
+        "gutenberg2zim.sources.opentextbooks.pipeline.download_html_edition",
+        return_value=edition,
+    ) as mirror:
         pipeline.process_ref(WorkRef(id="10", source="opentextbooks"))
 
     mirror.assert_not_called()
@@ -229,7 +236,7 @@ def test_process_ref_accepts_a_valid_epub_archive():
         ],
     )
     engine = MagicMock()
-    engine.fetch_bytes.return_value = b"PK\x03\x04 epub bytes"
+    engine.fetch_bytes.return_value = _valid_epub()
     assembler = MagicMock()
     pipeline = _pipeline(work, engine, assembler)
 
@@ -239,7 +246,7 @@ def test_process_ref_accepts_a_valid_epub_archive():
     assert "epub" not in work.extra["unsupported_formats"]
     assembler.add_item_for.assert_called_once_with(
         path="Calculus.10.epub",
-        content=b"PK\x03\x04 epub bytes",
+        content=_valid_epub(),
         mimetype="application/epub+zip",
         is_front=False,
     )


### PR DESCRIPTION
Closes #555
## Summary

Centralize downloaded-content validation into the shared core validation layer and remove the OTL-local validator.

## Changes

- Add shared validation for:
  - HTML/error-page responses
  - PDF signature validation
  - EPUB ZIP validation
  - EPUB mimetype verification
  - empty/corrupt/arbitrary ZIP rejection
- Switch OTL to use the shared validator.
- Add dedicated validation tests.
- Update OTL tests to use a valid ZIP-based EPUB fixture.

## Validation

Standalone validation checks for the important edge cases pass.

The branch is based directly on upstream `openzim/gutenberg:main` and contains one commit:

`feffbe6a6fa4ed4c8c891e6287e882f405a7d727`

The full repository test suite/CI has not been claimed as passing because it has not yet been run through an upstream PR.