### PR TITLE
Fix books display to not have 'floating' things anymore

### DIFF
--- a/ui/src/components/book/CollectionBookCard.vue
+++ b/ui/src/components/book/CollectionBookCard.vue
@@ -22,15 +22,17 @@ const { t } = useI18n()
       class="collection-book-cover"
     />
 
-    <h3 class="collection-book-title mb-1">
-      {{ book.title }}
-    </h3>
+    <div class="collection-book-info">
+      <h3 class="collection-book-title mb-1">
+        {{ book.title }}
+      </h3>
 
-    <p class="collection-book-author mb-2">
-      {{ book.author?.name }}
-    </p>
+      <p class="collection-book-author mb-2">
+        {{ book.author?.name }}
+      </p>
+    </div>
 
-    <fire-rating :popularity="book.popularity" />
+    <fire-rating :popularity="book.popularity" class="collection-book-fire-rating" />
   </router-link>
 </template>
 
@@ -56,7 +58,16 @@ const { t } = useI18n()
 }
 
 .collection-book-cover {
+  flex: 0 0 220px;
   margin-bottom: 12px;
+}
+
+.collection-book-cover :deep(.v-img__img) {
+  object-position: top;
+}
+
+.collection-book-info {
+  min-height: calc(v-bind(TYPOGRAPHY.H3_SIZE) * 1.4 * 3 + v-bind(TYPOGRAPHY.CAPTION_SIZE) * 1.4);
 }
 
 .collection-book-title {
@@ -76,11 +87,17 @@ const { t } = useI18n()
   font-family: v-bind(TYPOGRAPHY.FONT_FAMILY);
   font-size: v-bind(TYPOGRAPHY.CAPTION_SIZE);
   font-weight: v-bind(TYPOGRAPHY.CAPTION_WEIGHT);
+  line-height: 1.4;
+  min-height: calc(v-bind(TYPOGRAPHY.CAPTION_SIZE) * 1.4);
   color: rgb(var(--v-theme-text));
   opacity: 0.6;
   margin: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.collection-book-fire-rating {
+  margin-top: auto;
 }
 </style>


### PR DESCRIPTION
## Goal
- cover image always occupies same vertical space (220px) so that it does not matter if it is a very thin vertical image or a landscape one, title is always at the same position on all cards
- cover image is always centered horizontally and aligned to the top of the space
- title + author always occupies same vertical space ; which in turn means that fire rating is aligned to the bottom of the card

## Overview 

Before:

<img width="764" height="416" alt="image" src="https://github.com/user-attachments/assets/8bf216bd-9eee-4126-b06e-8db1135d2e39" />

After:

<img width="762" height="393" alt="image" src="https://github.com/user-attachments/assets/5d295221-8609-4460-9bdc-6775a1d20525" />

(with **exactly** the same images, I did not tricked)


## How

1. wrap `collection-book-title` and `collection-book-author` in a `collection-book-info`

2. adjust cover space

```css
.collection-book-cover {
  /* Override Vuetify's default `flex: 1 0 auto` on v-responsive/v-img, which
     would otherwise let the cover grow to absorb any leftover row height and
     make the cover zone taller than 240px on shorter cards. */
  flex: 0 0 220px;
}
```

3. keep image fixed size

```css
.collection-book-cover :deep(.v-img__img) {
  /* Keep the fixed-size zone regardless of the source image's own aspect
     ratio, aligning it to the top and centering it horizontally instead of
     the browser default of centering both axes. */
  object-position: top;
}
```

4. make line height constant + reserve space for title + author

```css
.collection-book-info {
  /* Reserve space for 3 title lines + 1 author line so every card's fire
     rating lands at the same height, regardless of the title's actual line
     count. Title and author sit at the top of this zone (author right after
     the title); any leftover space falls below the author, not between
     title and author. */
  min-height: calc(
    v-bind(TYPOGRAPHY.H3_SIZE) * 1.4 * 3 + v-bind(TYPOGRAPHY.CAPTION_SIZE) * 1.4
  );
}

.collection-book-title {
  line-height: 1.4;
}

.collection-book-author {
  line-height: 1.4;
  min-height: calc(v-bind(TYPOGRAPHY.CAPTION_SIZE) * 1.4);
}
```

5. pin flames to the bottom

```css
.collection-book-fire-rating {
  /* Pin to the bottom of the card regardless of how much space the title +
     author zone actually uses. */
  margin-top: auto;
}
```
