### PR TITLE
Fix double/doubled card borders and their alignment across grids and carousels

### DIFF
--- a/ui/src/assets/main.css
+++ b/ui/src/assets/main.css
@@ -6,8 +6,6 @@
 
 :root {
   --g-card-border: 1.5px;
-  --g-card-bleed: calc(var(--g-card-border) / 2);
-  --g-card-negative-bleed: calc(var(--g-card-bleed) * -1);
 }
 
 body {

--- a/ui/src/components/author/AuthorCard.vue
+++ b/ui/src/components/author/AuthorCard.vue
@@ -59,7 +59,17 @@ const isCarousel = () => props.variant === 'carousel'
   justify-content: center;
   width: 100%;
   height: 100%;
-  border: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  /* Right/bottom carry a border so no two adjacent cards ever paint the
+     same seam (see CollectionBookCard.vue for the full rationale). Top is
+     each card's own too — safe since this only ever sits in a single-row
+     carousel, so no other card shares that edge — which also avoids the
+     carousel track's border-top overshooting past a short row (see
+     AuthorDetailCarousel.vue's .carousel-track). Left is not drawn here at
+     all — it's only ever needed on the first card in the row, and
+     .carousel-cell:first-child (in the parent) adds it there directly. */
+  border-top: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-right: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-bottom: var(--g-card-border) solid rgb(var(--v-theme-grid));
   background: rgb(var(--v-theme-background));
   color: rgb(var(--v-theme-text));
   position: relative;
@@ -69,7 +79,6 @@ const isCarousel = () => props.variant === 'carousel'
 
 .author-card--carousel:hover,
 .author-card--carousel:focus {
-  border-color: rgb(var(--v-theme-grid));
   box-shadow: 0 0 10px 0 rgb(var(--v-theme-grid));
   z-index: 1;
 }

--- a/ui/src/components/author/AuthorDetailCarousel.vue
+++ b/ui/src/components/author/AuthorDetailCarousel.vue
@@ -182,10 +182,15 @@ watch(
 .carousel-track {
   display: flex;
   width: 100%;
-  padding: var(--g-card-bleed);
   align-items: stretch;
   height: 220px;
   scrollbar-width: none;
+  /* No border-left here (see .carousel-cell:first-child below) and no
+     border-top: a horizontal border's length always equals the full track
+     width, which would overshoot past the actual cells whenever there are
+     fewer than fill the track (e.g. an author with only 1-2 other
+     authors). Every cell draws its own border-top instead — safe since
+     this is a single row, so no two cells ever share a top seam. */
 }
 
 .carousel-track.g-mobile-only {
@@ -202,21 +207,28 @@ watch(
   justify-content: center;
 }
 
-.carousel-cell {
-  height: calc(100% + var(--g-card-border));
-  margin: var(--g-card-negative-bleed);
-}
-
 .carousel-cell--current {
-  /* 441.5px = 2 book grid cells (220px each) + 1.5px border overlap */
-  flex: 0 0 441.5px;
+  /* 440px = 2 book grid cells (220px each) */
+  flex: 0 0 440px;
 }
 
 .carousel-cell--small {
-  /* Book grid cells are 221.5px (220px + 1.5px border bleed). Match that. */
-  width: 221.5px;
-  min-width: 221.5px;
+  /* Match a book grid cell's width. */
+  width: 220px;
+  min-width: 220px;
   flex-shrink: 0;
+}
+
+.carousel-cell:first-child {
+  /* Left border lives on the first cell itself rather than the track: on
+     mobile the track scrolls, so a border on the track's own (fixed)
+     edge would stay put and keep showing even once you've scrolled past
+     the first cell. Anchoring it to the cell instead means it scrolls
+     away with that cell, and it's sized to just the cell's own height
+     rather than the track's full height (which includes vertical padding
+     added below for shadow clearance — that padding would otherwise make
+     the border taller than the actual card). */
+  border-left: var(--g-card-border) solid rgb(var(--v-theme-grid));
 }
 
 .current-author {
@@ -226,7 +238,13 @@ watch(
   padding: 1.5rem 2rem;
   width: 100%;
   height: 100%;
-  border: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  /* Top/right/bottom are each cell's own responsibility (see
+     .carousel-track above for why top moved here). Left is not drawn here
+     at all — it's only ever needed on the first cell in the row, and
+     .carousel-cell:first-child (in the parent) adds it there directly. */
+  border-top: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-right: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-bottom: var(--g-card-border) solid rgb(var(--v-theme-grid));
   background: rgba(var(--v-theme-text), 0.08);
   position: relative;
   z-index: 0;
@@ -235,7 +253,6 @@ watch(
 
 .current-author:hover,
 .current-author:focus {
-  border-color: rgb(var(--v-theme-grid));
   box-shadow: none;
   z-index: 0;
 }
@@ -281,7 +298,7 @@ watch(
 
   .carousel-track {
     display: flex;
-    padding: 5px var(--g-card-bleed); /* extra padding so box-shadow isn't clipped by overflow-x */
+    padding: 5px 0; /* extra vertical padding so box-shadow isn't clipped by overflow-x */
     height: 170px;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
@@ -299,8 +316,6 @@ watch(
 
   .carousel-cell {
     flex: 0 0 75%;
-    height: calc(100% + var(--g-card-border));
-    margin: var(--g-card-negative-bleed);
     scroll-snap-align: center;
   }
 
@@ -323,7 +338,6 @@ watch(
 
   .current-author:hover,
   .current-author:focus {
-    border-color: rgb(var(--v-theme-grid));
     box-shadow: none;
     z-index: 0;
   }

--- a/ui/src/components/book/BooksGrid.vue
+++ b/ui/src/components/book/BooksGrid.vue
@@ -11,37 +11,62 @@ const isCollectionPage = useIsCollectionPage()
 </script>
 
 <template>
-  <div class="books-grid" :class="{ 'books-grid--collection-view': isCollectionPage }">
-    <div v-for="book in books" :key="book.id" class="grid-cell">
-      <collection-book-card :book="book" />
+  <div class="books-grid-outer" :class="{ 'books-grid-outer--collection-view': isCollectionPage }">
+    <div class="books-grid">
+      <div v-for="book in books" :key="book.id" class="grid-cell">
+        <collection-book-card :book="book" />
+      </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.books-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, 220px);
-  justify-content: center;
-  padding: var(--g-card-bleed);
-  max-width: var(--g-layout-max);
+/* This outer box establishes a fixed, centered column at max-width,
+   regardless of how many cards actually render — it's what keeps a
+   half-empty last row (or a whole grid with only 1-2 cards) anchored at the
+   same left edge as a full row, instead of .books-grid's own fit-content
+   shrinking (needed below) also shrinking *where the block sits* and
+   re-centering a mostly-empty grid in the middle of the page. */
+.books-grid-outer {
+  --books-grid-max-width: var(--g-layout-max);
+  max-width: var(--books-grid-max-width);
   margin-inline: auto;
 }
 
-.books-grid--collection-view {
-  max-width: 882px;
+.books-grid-outer--collection-view {
+  --books-grid-max-width: 882px;
+}
+
+.books-grid {
+  display: grid;
+  /* auto-fit (not auto-fill): auto-fill would still create as many column
+     tracks as fit the available width even when there are fewer cards than
+     that — those extra empty tracks still count toward width: fit-content
+     below, stretching border-top/left past the actual cards. auto-fit
+     collapses any trailing tracks nothing got placed into. */
+  grid-template-columns: repeat(auto-fit, 220px);
+  /* `width: fit-content` shrinks the box to exactly the rendered tracks —
+     no leftover slack — so border-top/left below line up exactly with
+     row-1/column-1's own edges. It still needs its own max-width (inherited
+     from .books-grid-outer via the custom property above): auto-fit can't
+     tell how much space it has to fill without a definite bound declared
+     on this same element — a parent already being that width isn't enough.
+     No margin-inline/justify-content centering here though: this grid
+     stays left-aligned within .books-grid-outer, which is what's actually
+     centered on the page. */
+  width: fit-content;
+  max-width: var(--books-grid-max-width);
+  /* Cards only draw their own border-right/border-bottom (see
+     CollectionBookCard.vue), so no two cards ever paint the same seam. The
+     grid supplies the missing top/left edge once, for every cell in row 1
+     (top) and column 1 (left). */
+  border-top: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-left: var(--g-card-border) solid rgb(var(--v-theme-grid));
 }
 
 @media (max-width: 1279px) {
-  .books-grid,
-  .books-grid--collection-view {
-    grid-template-columns: repeat(auto-fill, 160px);
+  .books-grid {
+    grid-template-columns: repeat(auto-fit, 160px);
   }
-}
-
-.grid-cell {
-  width: calc(100% + var(--g-card-border));
-  height: calc(100% + var(--g-card-border));
-  margin: var(--g-card-negative-bleed);
 }
 </style>

--- a/ui/src/components/book/CollectionBookCard.vue
+++ b/ui/src/components/book/CollectionBookCard.vue
@@ -45,14 +45,21 @@ const { t } = useI18n()
   position: relative;
   z-index: 0;
   color: inherit;
-  border: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  /* Only the right/bottom edges carry a border. Two adjacent cards would
+     otherwise each draw a border on their shared edge — even lined up
+     pixel-perfectly, the two independently anti-aliased edges stack and
+     read as a visibly darker/thicker seam (most obvious at 4-way grid
+     corners, where up to 4 cards' edges pile up). Drawing each seam exactly
+     once avoids that entirely. The grid/row container supplies the
+     top/left edge of the whole layout once, since no card does. */
+  border-right: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-bottom: var(--g-card-border) solid rgb(var(--v-theme-grid));
   padding: 1rem 1.25rem;
   transition: box-shadow 0.2s ease;
 }
 
 .collection-book-card:hover,
 .collection-book-card:focus {
-  border-color: rgb(var(--v-theme-grid));
   box-shadow: 0 0 10px 0 rgb(var(--v-theme-grid));
   z-index: 1;
 }

--- a/ui/src/components/book/CollectionCarousel.vue
+++ b/ui/src/components/book/CollectionCarousel.vue
@@ -59,9 +59,11 @@ watch(
           </div>
         </div>
 
-        <div ref="trackRef" class="collection-books-row g-mobile-only">
-          <div v-for="book in books" :key="book.id" class="carousel-card-wrapper">
-            <collection-book-card :book="book" />
+        <div ref="trackRef" class="collection-books-scroll g-mobile-only">
+          <div class="collection-books-row">
+            <div v-for="book in books" :key="book.id" class="carousel-card-wrapper">
+              <collection-book-card :book="book" />
+            </div>
           </div>
         </div>
       </div>
@@ -107,26 +109,38 @@ watch(
 .collection-books-row {
   display: flex;
   align-items: stretch;
-  width: 100%;
-  padding: var(--g-card-bleed);
+  /* Shrinks to exactly the rendered cards instead of stretching to the full
+     track width — otherwise border-top/left below would extend past a
+     short row (e.g. only 1-2 books) into empty space. */
+  width: fit-content;
+  /* Each card only draws its own right/bottom border (see
+     CollectionBookCard.vue), so no two cards ever paint the same seam. The
+     row supplies the top/left edge once, for whichever card ends up first —
+     flex packs from the left by default, so the row's own edge lines up
+     exactly with that card's edge with no extra math needed. */
+  border-top: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-left: var(--g-card-border) solid rgb(var(--v-theme-grid));
 }
 
-.collection-books-row.g-mobile-only {
+.collection-books-scroll.g-mobile-only {
   display: none;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+  /* This is the scrollable viewport, sized to the available width — the
+     .collection-books-row inside it (which carries the border) is left to
+     size itself to fit-content, so it doesn't stretch the border with it. */
+  width: 100%;
   padding: 5px;
 }
 
-.collection-books-row.g-mobile-only::-webkit-scrollbar {
+.collection-books-scroll.g-mobile-only::-webkit-scrollbar {
   display: none;
 }
 
 .carousel-card-wrapper {
   width: 220px;
   min-width: 220px;
-  margin: var(--g-card-negative-bleed);
   display: flex;
 }
 

--- a/ui/src/components/home/PopularCollectionBooks.vue
+++ b/ui/src/components/home/PopularCollectionBooks.vue
@@ -31,15 +31,31 @@ const topBooks = computed(() =>
 
 .popular-collection-books__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, 183.33px);
-  justify-content: center;
-  padding: var(--g-card-bleed);
-}
-
-.popular-collection-books__cell {
-  width: calc(100% + var(--g-card-border));
-  height: calc(100% + var(--g-card-border));
-  margin: var(--g-card-negative-bleed);
+  /* auto-fit (not auto-fill): auto-fill would still create as many column
+     tracks as fit the available width even when there are fewer cards than
+     that — those extra empty tracks still count toward width: fit-content
+     below, stretching border-top/left past the actual cards. auto-fit
+     collapses any trailing tracks nothing got placed into. */
+  grid-template-columns: repeat(auto-fit, 183.33px);
+  /* `width: fit-content` shrinks the box to exactly the rendered tracks —
+     no leftover slack — so border-top/left below line up exactly with
+     row-1/column-1's own edges. It still needs its own max-width: auto-fit
+     can't tell how much space it has to fill without a definite bound
+     declared on this same element — .popular-collection-books already
+     being that width isn't enough. No margin-inline/justify-content
+     centering here though: this grid stays left-aligned within
+     .popular-collection-books, which is what's actually centered on the
+     page — otherwise a half-empty row (or a grid with only 1-2 cards)
+     would re-center itself in the middle of the page instead of lining up
+     with a full row's left edge. */
+  width: fit-content;
+  max-width: var(--g-layout-max);
+  /* Cards only draw their own border-right/border-bottom (see
+     CollectionBookCard.vue), so no two cards ever paint the same seam. The
+     grid supplies the missing top/left edge once, for every cell in row 1
+     (top) and column 1 (left). */
+  border-top: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-left: var(--g-card-border) solid rgb(var(--v-theme-grid));
 }
 
 @media (max-width: 1279px) {
@@ -48,7 +64,7 @@ const topBooks = computed(() =>
   }
 
   .popular-collection-books__grid {
-    grid-template-columns: repeat(auto-fill, 160px);
+    grid-template-columns: repeat(auto-fit, 160px);
   }
 }
 

--- a/ui/src/components/home/SelectedBooksSection.vue
+++ b/ui/src/components/home/SelectedBooksSection.vue
@@ -113,14 +113,18 @@ function goToAuthor(id: string) {
   display: grid;
   grid-template-columns: repeat(4, 183.33px) 366.66px;
   grid-template-rows: repeat(2, auto);
+  /* Fixed (non-auto-fill) tracks, so fit-content already matches their
+     total size exactly — no leftover slack — and border-top/left below
+     line up exactly with row-1/column-1's own edges. */
+  width: fit-content;
   justify-content: center;
-  padding: var(--g-card-bleed);
-}
-
-.selected-books-section__cell {
-  width: calc(100% + var(--g-card-border));
-  height: calc(100% + var(--g-card-border));
-  margin: var(--g-card-negative-bleed);
+  margin-inline: auto;
+  /* Cards only draw their own border-right/border-bottom (see
+     CollectionBookCard.vue), so no two cards ever paint the same seam. The
+     grid supplies the missing top/left edge once, for every cell in row 1
+     (top) and column 1 (left). */
+  border-top: var(--g-card-border) solid rgb(var(--v-theme-grid));
+  border-left: var(--g-card-border) solid rgb(var(--v-theme-grid));
 }
 
 .selected-books-section__featured {
@@ -129,9 +133,8 @@ function goToAuthor(id: string) {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  width: calc(100% + var(--g-card-border));
-  height: calc(100% + var(--g-card-border));
-  margin-top: var(--g-card-negative-bleed);
+  width: 100%;
+  height: 100%;
   position: relative;
 }
 


### PR DESCRIPTION
Each card previously drew a full 4-side border, and adjacent cards overlapped via half-pixel negative margins to fake a single shared line. That overlap was fragile: independently-rounded fractional margins on different cells produced visibly doubled/thicker borders, most obvious as a dark blob at 4-way grid corners.

Replaced with a collapsed-border scheme: each card draws only its own border-right/border-bottom, so no two cards ever paint the same seam. The container (or, where a container can't safely span exactly the right width, the first cell) supplies the missing top/left edge once.

Fixed along the way:
- auto-fill grids (BooksGrid, PopularCollectionBooks) created as many column tracks as fit the viewport even with fewer cards than that, stretching the border past the real cards; switched to auto-fit, which collapses unused trailing tracks.
- width: fit-content (needed to shrink the border to the real cards) and margin-inline: auto (centering) can't live on the same element, or a sparse grid re-centers itself instead of staying flush with a full row's left edge; split into an outer centered wrapper and an inner left-aligned, fit-content grid.
- CollectionCarousel's mobile scroll row needed the same width:100% (viewport) vs fit-content (border) split, via a separate inner wrapper.
- AuthorDetailCarousel's mobile cells size via `flex: 0 0 75%` of the scroll viewport, so they can't use a fit-content wrapper (circular sizing); moved border-top onto each cell (safe, single row) and border-left onto the first cell specifically, so it scrolls away with that cell instead of staying pinned to the viewport edge, and is sized to the cell's own height instead of the track's padded height.

-- Created with AI, reviewed by human