### PR TITLE
Remove --primary-color/--secondary-color CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,6 @@ The Open Textbook Library-specific options are:
 --output=<output_folder>            Output folder
 --cache-dir=<cache_folder>          Optional persistent metadata and catalog cache
 
---primary-color=<color>             Primary UI color
---secondary-color=<color>           Secondary UI color
 --ui-dist=<ui_dist>                 Built UI distribution directory
 --debug                             Enable verbose output
 ```

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -166,20 +166,6 @@
       "required": false,
       "title": "Mirror URL",
       "description": "URL to a source mirror or API base. Defaults to the selected source's standard endpoint."
-    },
-    "primary_color": {
-      "type": "string",
-      "required": false,
-      "title": "Primary Color",
-      "description": "Custom primary color. Hex/HTML syntax (#1976D2)",
-      "pattern": "^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$"
-    },
-    "secondary_color": {
-      "type": "string",
-      "required": false,
-      "title": "Secondary Color",
-      "description": "Custom secondary color. Hex/HTML syntax (#424242)",
-      "pattern": "^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$"
     }
   },
   "zimMetadata": [

--- a/scraper/src/gutenberg2zim/cli.py
+++ b/scraper/src/gutenberg2zim/cli.py
@@ -44,8 +44,6 @@ Options:
   --mirror-url=<mirror_url>       Source mirror URL
   --output=<output_folder>        Output directory [default: ./output]
   --cache-dir=<cache_folder>      Persist caches here; pass again to reuse them
-  --primary-color=<color>         Custom primary color
-  --secondary-color=<color>       Custom secondary color
   --ui-dist=<ui_dist>             Vue UI distribution directory
   --debug                         Enable verbose output
 """

--- a/scraper/src/gutenberg2zim/config.py
+++ b/scraper/src/gutenberg2zim/config.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from zimscraperlib.image.probing import is_hex_color
 from zimscraperlib.inputs import compute_descriptions
 
 from gutenberg2zim.core.utils import ALL_FORMATS, critical_error
@@ -45,16 +44,6 @@ class ScrapeConfig:
     title_search: bool = False
     with_fulltext_index: bool = True
     stats_filename: str | None = None
-    primary_color: str | None = None
-    secondary_color: str | None = None
-
-
-def _validate_colors(primary_color: str | None, secondary_color: str | None) -> None:
-    """Validate hex color formats if provided"""
-    if primary_color and not is_hex_color(primary_color):
-        critical_error(f"--primary-color is not a valid hex color: {primary_color}")
-    if secondary_color and not is_hex_color(secondary_color):
-        critical_error(f"--secondary-color is not a valid hex color: {secondary_color}")
 
 
 def _was_option_supplied(value: object) -> bool:
@@ -99,9 +88,6 @@ def build_scrape_config(arguments: dict) -> ScrapeConfig:
 
     stats_filename: str | None = arguments.get("--stats-filename") or None
     publisher = arguments.get("--publisher") or "openZIM"
-    primary_color = arguments.get("--primary-color")
-    secondary_color = arguments.get("--secondary-color")
-    _validate_colors(primary_color, secondary_color)
 
     debug = arguments.get("--debug") or False
     output_folder = Path(
@@ -206,6 +192,4 @@ def build_scrape_config(arguments: dict) -> ScrapeConfig:
         title_search=title_search,
         with_fulltext_index=with_fulltext_index,
         stats_filename=stats_filename,
-        primary_color=primary_color,
-        secondary_color=secondary_color,
     )

--- a/scraper/src/gutenberg2zim/core/exporters/json_exporter.py
+++ b/scraper/src/gutenberg2zim/core/exporters/json_exporter.py
@@ -158,8 +158,6 @@ def generate_json_files(
     title: str | None = None,
     description: str | None = None,
     *,
-    primary_color: str | None = None,
-    secondary_color: str | None = None,
     display_name: str,
     indexes: Indexes,
     source_slug: str = "source",
@@ -235,16 +233,12 @@ def generate_json_files(
     config = Config(
         title=title or zim_name or f"{display_name} Library",
         description=description,
-        primary_color=primary_color,
-        secondary_color=secondary_color,
         source=SourceInfo(
             slug=source_slug,
             name=display_name,
             description=source_description or display_name,
         ),
         theme=ThemeConfig(
-            primary_color=primary_color,
-            secondary_color=secondary_color,
             format_icons={format_name: format_name for format_name in formats},
             route_labels={
                 "home": "Home",

--- a/scraper/src/gutenberg2zim/core/pipeline.py
+++ b/scraper/src/gutenberg2zim/core/pipeline.py
@@ -108,8 +108,6 @@ class Pipeline(ABC):
         zim_name: str,
         title: str | None = None,
         description: str | None = None,
-        primary_color: str | None = None,
-        secondary_color: str | None = None,
         # human-readable source name, used in ZIM titles, search entries
         # and No-JS page titles; the orchestrator passes
         # `SourceProfile.display_name`
@@ -129,8 +127,6 @@ class Pipeline(ABC):
         self.zim_name = zim_name
         self.title = title
         self.description = description
-        self.primary_color = primary_color
-        self.secondary_color = secondary_color
         self.display_name = display_name
         self.source_slug = source_slug
         self.source_description = source_description
@@ -214,8 +210,6 @@ class Pipeline(ABC):
             assembler=self.assembler,
             title=self.title,
             description=self.description,
-            primary_color=self.primary_color,
-            secondary_color=self.secondary_color,
             display_name=self.display_name,
             source_slug=self.source_slug,
             source_description=self.source_description,

--- a/scraper/src/gutenberg2zim/core/schemas.py
+++ b/scraper/src/gutenberg2zim/core/schemas.py
@@ -126,8 +126,6 @@ class SourceInfo(CamelModel):
 class ThemeConfig(CamelModel):
     """Source-specific UI presentation settings."""
 
-    primary_color: str | None = None
-    secondary_color: str | None = None
     format_icons: dict[str, str]
     route_labels: dict[str, str]
     collection_icon_style: str = "classification"
@@ -146,8 +144,6 @@ class Config(CamelModel):
 
     title: str
     description: str | None = None
-    primary_color: str | None = None
-    secondary_color: str | None = None
     source: SourceInfo
     theme: ThemeConfig
     features: FeatureFlags

--- a/scraper/src/gutenberg2zim/orchestrator.py
+++ b/scraper/src/gutenberg2zim/orchestrator.py
@@ -166,8 +166,6 @@ def build_zimfile(
     ui_dist = config.ui_dist
     # build_scrape_config always resolves ui_dist (CLI arg, env var, or default)
     assert ui_dist is not None  # noqa: S101
-    primary_color = config.primary_color
-    secondary_color = config.secondary_color
     overwrite = config.overwrite
     is_selection = config.is_selection
     title_search = config.title_search
@@ -277,8 +275,6 @@ def build_zimfile(
             zim_name=zim_name,
             title=title,
             description=description,
-            primary_color=primary_color,
-            secondary_color=secondary_color,
             display_name=profile.display_name,
             source_slug=profile.slug,
             source_description=profile.source_description,

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -23,7 +23,7 @@ mainStore
   .fetchConfig()
   .then((config) => {
     setRouterConfig(config)
-    return Promise.all([loadI18n(config.source.slug), loadVuetify(config)])
+    return Promise.all([loadI18n(config.source.slug), loadVuetify()])
   })
   .then(([i18n, vuetify]) => {
     const app = createApp(App)

--- a/ui/src/plugins/vuetify.ts
+++ b/ui/src/plugins/vuetify.ts
@@ -1,10 +1,9 @@
 import 'vuetify/styles'
 import '@mdi/font/css/materialdesignicons.css'
 import { createVuetify, type ThemeDefinition } from 'vuetify'
-import type { Config } from '@/types/Config'
 import { THEME_COLORS } from '@/constants/theme'
 
-async function loadVuetify(config: Config) {
+async function loadVuetify() {
   const PRIMARY = '#1976D2'
   const SECONDARY = '#424242'
   const ACCENT = '#82B1FF'
@@ -17,15 +16,9 @@ async function loadVuetify(config: Config) {
   const SURFACE_LIGHT = '#FAFAFA'
   const SURFACE_DARK = '#1E1E1E'
 
-  let primaryColor: string = PRIMARY
-  let secondaryColor: string = SECONDARY
-
-  primaryColor = config.primaryColor || primaryColor
-  secondaryColor = config.secondaryColor || secondaryColor
-
   const sharedColors = {
-    primary: primaryColor,
-    secondary: secondaryColor,
+    primary: PRIMARY,
+    secondary: SECONDARY,
     accent: ACCENT,
     error: ERROR,
     info: INFO,

--- a/ui/src/stores/main.integration.spec.ts
+++ b/ui/src/stores/main.integration.spec.ts
@@ -89,16 +89,12 @@ describe('Main Store Integration', () => {
       const mockConfig: Config = {
         title: 'Test Library',
         description: 'Test source books',
-        primaryColor: null,
-        secondaryColor: null,
         source: {
           slug: 'test-source',
           name: 'Test Source',
           description: 'Test source books'
         },
         theme: {
-          primaryColor: null,
-          secondaryColor: null,
           formatIcons: { epub: 'epub', html: 'html' },
           routeLabels: {
             home: 'Home',

--- a/ui/src/types/Config.ts
+++ b/ui/src/types/Config.ts
@@ -5,8 +5,6 @@ export interface SourceInfo {
 }
 
 export interface ThemeConfig {
-  primaryColor: string | null
-  secondaryColor: string | null
   formatIcons: Record<string, string>
   routeLabels: Record<string, string>
   collectionIconStyle: 'classification' | 'subject'
@@ -21,8 +19,6 @@ export interface FeatureFlags {
 export interface Config {
   title: string
   description: string | null
-  primaryColor: string | null
-  secondaryColor: string | null
   source: SourceInfo
   theme: ThemeConfig
   features: FeatureFlags


### PR DESCRIPTION
These flags are now only recoloring a handful of minor accents (a button, a spinner, some avatars), never the UI's actual branding, which is now fully fixed and opinionated. 

Drops the flags, the redundant duplicate config.json fields (Config and ThemeConfig both carried them), and the offliner-definition.json schema entries.